### PR TITLE
Switch pre-commit hook to Husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+npm run build
+npm test

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A sophisticated arbitrage trading bot for the GalaChain gSwap DEX built with Nod
    cd gala-trading-bot
    npm install
    ```
+   > The installation step sets up a Husky-powered Git pre-commit hook that runs `npm run build` and `npm test` before every commit. Re-run `npm run prepare` if you ever need to reinstall the hook manually.
 
 2. **Configure Environment**
    ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "husky": "^9.1.6",
         "jest": "^30.1.3",
         "ts-jest": "^29.4.3"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --ci --coverage --watchAll=false"
+    "test:ci": "jest --ci --coverage --watchAll=false",
+    "prepare": "husky install"
   },
   "keywords": [],
   "author": "",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "husky": "^9.1.6",
     "jest": "^30.1.3",
     "ts-jest": "^29.4.3"
   }


### PR DESCRIPTION
## Summary
- remove the custom Node installer script for the pre-commit hook
- add Husky as a dev dependency with a pre-commit hook that runs build and test
- document the Husky-based setup flow in the Quick Start guide

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd508c2d0083289ba08da4ac2b78dd