### PR TITLE
Prune unused GSwap token helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { GSwapAPI, TradingPair } from './api/gswap';
+import { GSwapAPI, TradingPair, QuoteMap } from './api/gswap';
 import { ArbitrageDetector, ArbitrageOpportunity } from './strategies/arbitrage';
 import { TradeExecutor } from './trader/executor';
 import { MockTradeExecutor } from './mock/mockTradeExecutor';
@@ -112,11 +112,11 @@ class GalaTradingBot {
 
     try {
       // Step 1: Fetch market data
-      const pairs = await this.fetchMarketData();
+      const { pairs, quoteMap } = await this.fetchMarketData();
       console.log(`📊 Fetched ${pairs.length} trading pairs`);
 
       // Step 2: Detect arbitrage opportunities
-      const opportunities = await this.detector.detectAllOpportunities(pairs, this.api);
+      const opportunities = await this.detector.detectAllOpportunities(pairs, this.api, quoteMap);
       console.log(`🔍 Found ${opportunities.length} arbitrage opportunities`);
 
       // Step 2.5: Check for opportunities without sufficient funds
@@ -138,11 +138,12 @@ class GalaTradingBot {
     }
   }
 
-  private async fetchMarketData(): Promise<TradingPair[]> {
+  private async fetchMarketData(): Promise<{ pairs: TradingPair[]; quoteMap: QuoteMap }> {
     try {
       // Fetch trading pairs from gSwap
       const pairs = await this.api.getTradingPairs();
-      return pairs;
+      const quoteMap = this.api.getLatestQuoteMap();
+      return { pairs, quoteMap };
     } catch (error) {
       console.error('❌ Failed to fetch market data:', error);
       throw error;


### PR DESCRIPTION
## Summary
- prune unused token lookup helpers from GSwapAPI so the streamlined API aligns with the latest main branch while retaining the concurrency-limited quote cache

## Testing
- npm run build
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cd4c63e1a88328a0c9d09910331fe2