### PR TITLE
Improve swap execution with cached quotes and adaptive retries

### DIFF
--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -27,13 +27,17 @@ export const createMockSwapQuote = (inputAmount: number, outputAmount: number): 
   route: ['GALA|Unit|none|none', 'GUSDC|Unit|none|none']
 });
 
-export const createMockSwapResult = (transactionHash: string): SwapResult => ({
+export const createMockSwapResult = (
+  transactionHash: string,
+  overrides: Partial<SwapResult> = {}
+): SwapResult => ({
   transactionHash,
   inputAmount: 1000,
   outputAmount: 25000,
   actualPrice: 0.04,
   gasUsed: 100000,
-  timestamp: Date.now()
+  timestamp: Date.now(),
+  ...overrides
 });
 
 export const createMockArbitrageOpportunity = (): ArbitrageOpportunity => ({


### PR DESCRIPTION
## Summary
- pass arbitrage quotes through the trade executor so swaps reuse cached pricing unless stale or invalid, and add adaptive retry delays
- teach the GSwap API wrapper to accept externally supplied quotes before falling back to live pricing
- extend the unit test helpers and coverage to validate the cached quote pathway

## Testing
- `npm test -- --runInBand` *(fails: jest binary unavailable in container)*
- `npm install` *(fails: 403 Forbidden retrieving dependencies from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6a62ce3c83289e28dde8dcc5e2aa