### PR TITLE
Refactor mock trading flow to centralize gSwap mocking

### DIFF
--- a/src/__tests__/api/gswap.mock.test.ts
+++ b/src/__tests__/api/gswap.mock.test.ts
@@ -1,0 +1,85 @@
+jest.mock('@gala-chain/gswap-sdk', () => {
+  const quoteExactInput = jest.fn();
+  const swap = jest.fn();
+  const getUserAssets = jest.fn();
+
+  class MockGSwap {
+    quoting = { quoteExactInput };
+    swaps = { swap };
+    assets = { getUserAssets };
+  }
+
+  return {
+    GSwap: jest.fn(() => new MockGSwap()),
+    PrivateKeySigner: jest.fn(),
+    stringifyTokenClassKey: jest.fn(({ collection, category, type, additionalKey }) =>
+      `${collection}|${category}|${type}|${additionalKey}`
+    ),
+    __mocks: {
+      quoteExactInput,
+      swap,
+      getUserAssets,
+    },
+  };
+});
+
+describe('GSwapAPI mock mode behavior', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.PRIVATE_KEY = '0xabc';
+    process.env.WALLET_ADDRESS = '0xwallet';
+    process.env.MOCK_MODE = 'true';
+    process.env.MOCK_WALLET_BALANCES = JSON.stringify({
+      'GALA|Unit|none|none': 1000,
+      'GUSDC|Unit|none|none': 0,
+    });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('executes swaps without calling on-chain swap and updates balances', async () => {
+    const sdk = await import('@gala-chain/gswap-sdk');
+    const { GSwapAPI } = await import('../../api/gswap');
+
+    const quoteMock = (sdk as any).__mocks.quoteExactInput as jest.Mock;
+    const swapMock = (sdk as any).__mocks.swap as jest.Mock;
+
+    quoteMock.mockResolvedValue({
+      outTokenAmount: { toNumber: () => 150 },
+      priceImpact: { toNumber: () => 0.1 },
+      feeTier: 0.003,
+    });
+
+    const api = new GSwapAPI();
+
+    const result = await api.executeSwap('GALA|Unit|none|none', 'GUSDC|Unit|none|none', 100);
+
+    expect(result.transactionHash).toMatch(/^mock_tx_/);
+    expect(result.outputAmount).toBe(150);
+    expect(swapMock).not.toHaveBeenCalled();
+
+    const snapshot = await api.getBalanceSnapshot();
+    expect(snapshot.getBalance('GALA|Unit|none|none')).toBeCloseTo(900);
+    expect(snapshot.getBalance('GUSDC|Unit|none|none')).toBeCloseTo(150);
+  });
+
+  it('provides mock balances without querying chain assets', async () => {
+    const sdk = await import('@gala-chain/gswap-sdk');
+    const assetsMock = (sdk as any).__mocks.getUserAssets as jest.Mock;
+    const { GSwapAPI } = await import('../../api/gswap');
+
+    const api = new GSwapAPI();
+
+    const snapshot = await api.getBalanceSnapshot(true);
+
+    expect(snapshot.getBalance('GALA|Unit|none|none')).toBeCloseTo(1000);
+    expect(snapshot.getBalance('GUSDC|Unit|none|none')).toBeCloseTo(0);
+    expect(assetsMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/streaming/eventProcessor.test.ts
+++ b/src/__tests__/streaming/eventProcessor.test.ts
@@ -14,21 +14,6 @@ jest.mock('../../strategies/arbitrage', () => ({
   }))
 }));
 
-// Mock the mock trade executor
-jest.mock('../../mock/mockTradeExecutor', () => ({
-  MockTradeExecutor: jest.fn().mockImplementation(() => ({
-    executeArbitrageTrade: jest.fn().mockResolvedValue(true),
-    getStats: jest.fn().mockReturnValue({
-      totalTransactions: 0,
-      arbitrageTrades: 0,
-      swapTrades: 0,
-      totalProfit: 0,
-      successRate: 100
-    }),
-    generateFinalReport: jest.fn()
-  }))
-}));
-
 describe('RealTimeEventProcessor', () => {
   let mockApi: jest.Mocked<GSwapAPI>;
   let eventProcessor: RealTimeEventProcessor;

--- a/src/__tests__/streaming/integration.test.ts
+++ b/src/__tests__/streaming/integration.test.ts
@@ -58,21 +58,6 @@ jest.mock('../../strategies/arbitrage', () => ({
   }))
 }));
 
-// Mock the mock trade executor
-jest.mock('../../mock/mockTradeExecutor', () => ({
-  MockTradeExecutor: jest.fn().mockImplementation(() => ({
-    executeArbitrageTrade: jest.fn().mockResolvedValue(true),
-    getStats: jest.fn().mockReturnValue({
-      totalTransactions: 1,
-      arbitrageTrades: 1,
-      swapTrades: 0,
-      totalProfit: 25,
-      successRate: 100
-    }),
-    generateFinalReport: jest.fn()
-  }))
-}));
-
 describe('Kafka Consumer Integration Tests', () => {
   let mockApi: jest.Mocked<GSwapAPI>;
   let eventProcessor: RealTimeEventProcessor;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,12 @@
 import { GSwapAPI, TradingPair, QuoteMap } from './api/gswap';
 import { ArbitrageDetector, ArbitrageOpportunity } from './strategies/arbitrage';
 import { TradeExecutor } from './trader/executor';
-import { MockTradeExecutor } from './mock/mockTradeExecutor';
 import { config, validateConfig } from './config';
 
 class GalaTradingBot {
   private api: GSwapAPI;
   private detector: ArbitrageDetector;
   private executor: TradeExecutor;
-  private mockExecutor: MockTradeExecutor;
   private isRunning: boolean = false;
   private pollingInterval?: NodeJS.Timeout;
 
@@ -16,7 +14,6 @@ class GalaTradingBot {
     this.api = new GSwapAPI();
     this.detector = new ArbitrageDetector();
     this.executor = new TradeExecutor(this.api);
-    this.mockExecutor = new MockTradeExecutor();
   }
 
   async start(): Promise<void> {
@@ -43,7 +40,7 @@ class GalaTradingBot {
       if (config.mockMode) {
         console.log('🎭 Mock mode enabled - trades will be simulated');
         console.log(`📁 Mock run name: ${config.mockRunName}`);
-        console.log(`💰 Initial balances:`, this.mockExecutor.getBalances());
+        console.log('💰 Initial balances:', config.mockWalletBalances);
       }
 
     } catch (error) {
@@ -59,11 +56,6 @@ class GalaTradingBot {
     
     if (this.pollingInterval) {
       clearInterval(this.pollingInterval);
-    }
-
-    // Generate mock trading report if in mock mode
-    if (config.mockMode) {
-      this.mockExecutor.generateFinalReport();
     }
 
     // Cancel all active trades
@@ -152,74 +144,37 @@ class GalaTradingBot {
 
 
   private async executeOpportunities(opportunities: ArbitrageOpportunity[]): Promise<void> {
-    if (config.mockMode) {
-      // Mock mode execution
-      const executableOpportunities = opportunities.filter(opp => opp.hasFunds);
-      
-      if (executableOpportunities.length === 0) {
-        console.log('⏳ No executable opportunities (insufficient funds for all opportunities)');
-        return;
-      }
+    const capacity = this.executor.getTradingCapacity();
 
-      // Execute the most profitable opportunities (limit to 3 for mock mode)
-      const opportunitiesToExecute = executableOpportunities.slice(0, 3);
-      
-      for (const opportunity of opportunitiesToExecute) {
-        try {
-          console.log(`\n💰 Executing mock opportunity: ${opportunity.tokenA} -> ${opportunity.tokenB}`);
-          console.log(`   Buy: ${opportunity.tokenClassA} @ ${opportunity.buyPrice.toFixed(6)}`);
-          console.log(`   Sell: ${opportunity.tokenClassB} @ ${opportunity.sellPrice.toFixed(6)}`);
-          console.log(`   Expected profit: ${opportunity.profitPercentage.toFixed(2)}%`);
-          console.log(`   Trade amount: ${opportunity.maxTradeAmount}`);
-          console.log(`   Balance: ${opportunity.currentBalance.toFixed(2)} ${opportunity.tokenClassA.split('|')[0]}`);
-          
-          // Execute mock trade
-          const success = await this.mockExecutor.executeArbitrageTrade(opportunity);
-          if (success) {
-            console.log(`✅ Mock trade executed successfully`);
-          }
-          
-        } catch (error) {
-          console.error(`❌ Error executing mock opportunity ${opportunity.id}:`, error);
-        }
-      }
-    } else {
-      // Real mode execution
-      const capacity = this.executor.getTradingCapacity();
-      
-      if (capacity.available <= 0) {
-        console.log(`⏳ No available slots for new trades (${capacity.current}/${capacity.max})`);
-        return;
-      }
+    if (capacity.available <= 0) {
+      console.log(`⏳ No available slots for new trades (${capacity.current}/${capacity.max})`);
+      return;
+    }
 
-      // Filter opportunities that have sufficient funds
-      const executableOpportunities = opportunities.filter(opp => opp.hasFunds);
-      
-      if (executableOpportunities.length === 0) {
-        console.log('⏳ No executable opportunities (insufficient funds for all opportunities)');
-        return;
-      }
+    const executableOpportunities = opportunities.filter(opp => opp.hasFunds);
 
-      // Execute the most profitable opportunities with sufficient funds
-      const opportunitiesToExecute = executableOpportunities.slice(0, capacity.available);
-      
-      for (const opportunity of opportunitiesToExecute) {
-        try {
-          console.log(`\n💰 Executing opportunity: ${opportunity.tokenA} -> ${opportunity.tokenB}`);
-          console.log(`   Buy: ${opportunity.tokenClassA} @ ${opportunity.buyPrice.toFixed(6)}`);
-          console.log(`   Sell: ${opportunity.tokenClassB} @ ${opportunity.sellPrice.toFixed(6)}`);
-          console.log(`   Expected profit: ${opportunity.profitPercentage.toFixed(2)}%`);
-          console.log(`   Trade amount: ${opportunity.maxTradeAmount}`);
-          console.log(`   Balance: ${opportunity.currentBalance.toFixed(2)} ${opportunity.tokenClassA.split('|')[0]}`);
-          
-          // Execute in background to avoid blocking
-          this.executor.executeArbitrage(opportunity).catch(error => {
-            console.error(`❌ Failed to execute opportunity ${opportunity.id}:`, error);
-          });
-          
-        } catch (error) {
-          console.error(`❌ Error executing opportunity ${opportunity.id}:`, error);
-        }
+    if (executableOpportunities.length === 0) {
+      console.log('⏳ No executable opportunities (insufficient funds for all opportunities)');
+      return;
+    }
+
+    const opportunitiesToExecute = executableOpportunities.slice(0, capacity.available);
+
+    for (const opportunity of opportunitiesToExecute) {
+      try {
+        console.log(`\n💰 Executing opportunity: ${opportunity.tokenA} -> ${opportunity.tokenB}`);
+        console.log(`   Buy: ${opportunity.tokenClassA} @ ${opportunity.buyPrice.toFixed(6)}`);
+        console.log(`   Sell: ${opportunity.tokenClassB} @ ${opportunity.sellPrice.toFixed(6)}`);
+        console.log(`   Expected profit: ${opportunity.profitPercentage.toFixed(2)}%`);
+        console.log(`   Trade amount: ${opportunity.maxTradeAmount}`);
+        console.log(`   Balance: ${opportunity.currentBalance.toFixed(2)} ${opportunity.tokenClassA.split('|')[0]}`);
+
+        this.executor.executeArbitrage(opportunity).catch(error => {
+          console.error(`❌ Failed to execute opportunity ${opportunity.id}:`, error);
+        });
+
+      } catch (error) {
+        console.error(`❌ Error executing opportunity ${opportunity.id}:`, error);
       }
     }
   }
@@ -250,43 +205,23 @@ class GalaTradingBot {
   }
 
   private logTradingStats(): void {
-    if (config.mockMode) {
-      // Mock mode statistics
-      const mockStats = this.mockExecutor.getStats();
-      const balances = this.mockExecutor.getBalances();
-      
-      console.log('\n🎭 Mock Trading Statistics:');
-      console.log(`   Total transactions: ${mockStats.totalTransactions}`);
-      console.log(`   Arbitrage trades: ${mockStats.arbitrageTrades}`);
-      console.log(`   Swap trades: ${mockStats.swapTrades}`);
-      console.log(`   Total profit: ${mockStats.totalProfit.toFixed(6)}`);
-      console.log(`   Success rate: ${mockStats.successRate.toFixed(2)}%`);
-      
-      console.log('\n💰 Current Balances:');
-      Object.entries(balances).forEach(([token, balance]) => {
-        const symbol = token.split('|')[0];
-        console.log(`   ${symbol}: ${balance.toFixed(6)}`);
+    const stats = this.executor.getTradingStats();
+    const activeTrades = this.executor.getActiveTrades();
+
+    console.log('\n📊 Trading Statistics:');
+    console.log(`   Total trades: ${stats.totalTrades}`);
+    console.log(`   Completed: ${stats.completedTrades}`);
+    console.log(`   Failed: ${stats.failedTrades}`);
+    console.log(`   Success rate: ${stats.successRate.toFixed(1)}%`);
+    console.log(`   Total profit: ${stats.totalProfit.toFixed(2)}`);
+    console.log(`   Average profit: ${stats.averageProfit.toFixed(2)}`);
+    console.log(`   Active trades: ${activeTrades.length}`);
+
+    if (activeTrades.length > 0) {
+      console.log('   Active trade statuses:');
+      activeTrades.forEach(trade => {
+        console.log(`     ${trade.id}: ${trade.status} (${trade.opportunity.tokenA} -> ${trade.opportunity.tokenB})`);
       });
-    } else {
-      // Real mode statistics
-      const stats = this.executor.getTradingStats();
-      const activeTrades = this.executor.getActiveTrades();
-      
-      console.log('\n📊 Trading Statistics:');
-      console.log(`   Total trades: ${stats.totalTrades}`);
-      console.log(`   Completed: ${stats.completedTrades}`);
-      console.log(`   Failed: ${stats.failedTrades}`);
-      console.log(`   Success rate: ${stats.successRate.toFixed(1)}%`);
-      console.log(`   Total profit: ${stats.totalProfit.toFixed(2)}`);
-      console.log(`   Average profit: ${stats.averageProfit.toFixed(2)}`);
-      console.log(`   Active trades: ${activeTrades.length}`);
-      
-      if (activeTrades.length > 0) {
-        console.log('   Active trade statuses:');
-        activeTrades.forEach(trade => {
-          console.log(`     ${trade.id}: ${trade.status} (${trade.opportunity.tokenA} -> ${trade.opportunity.tokenB})`);
-        });
-      }
     }
   }
 }

--- a/src/streamingBot.ts
+++ b/src/streamingBot.ts
@@ -52,9 +52,6 @@ class GalaStreamingBot {
     // Stop Kafka consumer
     await this.kafkaConsumer.stop();
 
-    // Generate mock trading report if in mock mode
-    this.eventProcessor.generateMockReport();
-
     // Cancel all active trades
     const activeTrades = this.executor.getActiveTrades();
     for (const trade of activeTrades) {
@@ -90,13 +87,6 @@ class GalaStreamingBot {
       blocksFiltered: number;
       opportunitiesFound: number;
       tradesExecuted: number;
-      mockStats?: {
-        totalTransactions: number;
-        arbitrageTrades: number;
-        swapTrades: number;
-        totalProfit: number;
-        successRate: number;
-      };
     };
     tradingStats: {
       totalTrades: number;
@@ -127,16 +117,6 @@ class GalaStreamingBot {
       console.log(`   Trades Executed: ${status.tradingStats.totalTrades}`);
       console.log(`   Success Rate: ${status.tradingStats.successRate.toFixed(1)}%`);
       console.log(`   Total Profit: ${status.tradingStats.totalProfit.toFixed(2)}`);
-      
-      // Show mock trading stats if in mock mode
-      if (status.processingStats.mockStats) {
-        console.log('\n🎭 Mock Trading Stats:');
-        console.log(`   Total Transactions: ${status.processingStats.mockStats.totalTransactions}`);
-        console.log(`   Arbitrage Trades: ${status.processingStats.mockStats.arbitrageTrades}`);
-        console.log(`   Swap Trades: ${status.processingStats.mockStats.swapTrades}`);
-        console.log(`   Total Profit: ${status.processingStats.mockStats.totalProfit.toFixed(6)}`);
-        console.log(`   Success Rate: ${status.processingStats.mockStats.successRate.toFixed(2)}%`);
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- teach `GSwapAPI` to virtualize wallet balances and swaps when MOCK_MODE is enabled so the rest of the bot can run unchanged
- simplify the trading and streaming flows to rely on the real trade executor while still honouring mock mode state
- add targeted unit tests covering the mocked swap/balance behaviour and update streaming tests for the new control flow

## Testing
- npm install (fails: npm error code E403 due to restricted registry)
- npm test (not run: jest unavailable without dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68cdb0881ac08328a9ca733c41ee6d2d