### PR TITLE
Refactor gSwap API into modular helpers

### DIFF
--- a/src/api/balanceManager.ts
+++ b/src/api/balanceManager.ts
@@ -1,0 +1,169 @@
+import { stringifyTokenClassKey } from '@gala-chain/gswap-sdk';
+import type { UserAssetsResponse } from './types';
+
+export class BalanceSnapshot {
+  private readonly balances: Map<string, number>;
+  readonly fetchedAt: number;
+
+  constructor(balances: Map<string, number>, fetchedAt: number) {
+    this.balances = balances;
+    this.fetchedAt = fetchedAt;
+  }
+
+  getBalance(tokenClass: string): number {
+    return this.balances.get(tokenClass) ?? 0;
+  }
+}
+
+export interface BalanceManagerOptions {
+  isMockMode: boolean;
+  balanceRefreshInterval: number;
+  mockWalletBalances: Record<string, number>;
+  fetchUserAssets: () => Promise<UserAssetsResponse>;
+}
+
+export class BalanceManager {
+  private balanceSnapshot: BalanceSnapshot | null = null;
+  private mockBalances: Map<string, number> | null = null;
+
+  constructor(private readonly options: BalanceManagerOptions) {}
+
+  async getSnapshot(forceRefresh: boolean = false): Promise<BalanceSnapshot> {
+    if (!forceRefresh && this.balanceSnapshot && !this.isSnapshotExpired(this.balanceSnapshot)) {
+      return this.balanceSnapshot;
+    }
+
+    try {
+      const snapshot = this.options.isMockMode
+        ? this.buildSnapshotFromMockBalances()
+        : await this.buildBalanceSnapshot();
+
+      this.balanceSnapshot = snapshot;
+      return snapshot;
+    } catch (error) {
+      console.error('Failed to refresh balance snapshot:', error);
+
+      if (this.balanceSnapshot) {
+        return this.balanceSnapshot;
+      }
+
+      const emptySnapshot = this.options.isMockMode
+        ? this.buildSnapshotFromMockBalances()
+        : new BalanceSnapshot(new Map(), Date.now());
+
+      this.balanceSnapshot = emptySnapshot;
+      return emptySnapshot;
+    }
+  }
+
+  async refreshSnapshot(): Promise<BalanceSnapshot> {
+    return this.getSnapshot(true);
+  }
+
+  async checkTradingFunds(requiredAmount: number, tokenClass: string, snapshot?: BalanceSnapshot): Promise<{
+    hasFunds: boolean;
+    currentBalance: number;
+    shortfall: number;
+  }> {
+    try {
+      const balanceSnapshot = snapshot ?? await this.getSnapshot();
+      const currentBalance = balanceSnapshot.getBalance(tokenClass);
+      const shortfall = Math.max(0, requiredAmount - currentBalance);
+
+      return {
+        hasFunds: currentBalance >= requiredAmount,
+        currentBalance,
+        shortfall,
+      };
+    } catch (error) {
+      console.error(`Failed to check trading funds for ${tokenClass}:`, error);
+      return {
+        hasFunds: false,
+        currentBalance: 0,
+        shortfall: requiredAmount,
+      };
+    }
+  }
+
+  applyMockSwap(
+    inputTokenClass: string,
+    outputTokenClass: string,
+    inputAmount: number,
+    outputAmount: number
+  ): void {
+    if (!this.options.isMockMode) {
+      return;
+    }
+
+    const balances = this.getMockBalances();
+    const currentInput = balances.get(inputTokenClass) ?? 0;
+
+    if (currentInput < inputAmount) {
+      throw new Error(`Insufficient mock balance for ${inputTokenClass}`);
+    }
+
+    balances.set(inputTokenClass, currentInput - inputAmount);
+
+    const currentOutput = balances.get(outputTokenClass) ?? 0;
+    balances.set(outputTokenClass, currentOutput + outputAmount);
+
+    this.balanceSnapshot = this.buildSnapshotFromMockBalances();
+  }
+
+  private async buildBalanceSnapshot(): Promise<BalanceSnapshot> {
+    const userAssets = await this.options.fetchUserAssets();
+    const balances = new Map<string, number>();
+
+    const tokens = userAssets?.tokens ?? [];
+    for (const token of tokens) {
+      const tokenClass = stringifyTokenClassKey({
+        collection: token.collection ?? token.symbol,
+        category: token.category ?? 'Unit',
+        type: token.type ?? 'none',
+        additionalKey: token.additionalKey ?? 'none',
+      });
+
+      const quantity = parseFloat(token.quantity ?? '0');
+      if (!Number.isNaN(quantity)) {
+        balances.set(tokenClass, quantity);
+      }
+    }
+
+    return new BalanceSnapshot(balances, Date.now());
+  }
+
+  private isSnapshotExpired(snapshot: BalanceSnapshot): boolean {
+    if (this.options.balanceRefreshInterval === 0) {
+      return false;
+    }
+
+    return Date.now() - snapshot.fetchedAt >= this.options.balanceRefreshInterval;
+  }
+
+  private getMockBalances(): Map<string, number> {
+    if (!this.mockBalances) {
+      this.initializeMockBalances();
+    }
+
+    return this.mockBalances!;
+  }
+
+  private initializeMockBalances(): void {
+    this.mockBalances = new Map<string, number>();
+
+    for (const [tokenClass, quantity] of Object.entries(this.options.mockWalletBalances)) {
+      this.mockBalances.set(tokenClass, quantity);
+    }
+  }
+
+  private buildSnapshotFromMockBalances(): BalanceSnapshot {
+    const balances = new Map<string, number>();
+    const mockBalances = this.getMockBalances();
+
+    for (const [tokenClass, quantity] of mockBalances.entries()) {
+      balances.set(tokenClass, quantity);
+    }
+
+    return new BalanceSnapshot(balances, Date.now());
+  }
+}

--- a/src/api/gswap.ts
+++ b/src/api/gswap.ts
@@ -1,258 +1,82 @@
-import { GSwap, PrivateKeySigner, stringifyTokenClassKey } from '@gala-chain/gswap-sdk';
+import { GSwap, PrivateKeySigner } from '@gala-chain/gswap-sdk';
 import { config } from '../config';
+import { BalanceManager, BalanceSnapshot } from './balanceManager';
+import { buildQuoteCacheKey, cloneQuoteMap } from './quotes';
+import { createTokenClassKey, TokenRegistry } from './tokenRegistry';
+import type {
+  QuoteCacheEntry,
+  QuoteMap,
+  SwapQuote,
+  SwapResult,
+  TokenInfo,
+  TradingPair,
+  UserAssetsResponse,
+} from './types';
 
-// Types for GalaSwap API responses
-interface GalaSwapToken {
-  collection: string;
-  category: string;
-  type: string;
-  additionalKey: string;
-  decimals: string;
-  quantity: string;
-  compositeKey: string;
-  image: string;
-  name: string;
-  symbol: string;
-  description: string;
-  verify: boolean;
-}
-
-interface GalaSwapTokenListResponse {
-  status: number;
-  error: boolean;
-  message: string;
-  data: {
-    token: GalaSwapToken[];
-    count: number;
-  };
-}
-
-export interface TokenInfo {
-  symbol: string;
-  name: string;
-  decimals: number;
-  tokenClass: string; // Format: "SYMBOL|Unit|none|none"
-  price: number;
-  priceChange24h: number;
-}
-
-export interface TradingPair {
-  tokenA: TokenInfo;
-  tokenB: TokenInfo;
-  tokenClassA: string;
-  tokenClassB: string;
-}
-
-export interface SwapQuote {
-  inputToken: string;
-  outputToken: string;
-  inputAmount: number;
-  outputAmount: number;
-  priceImpact: number;
-  feeTier: number;
-  route: string[];
-}
-
-export interface QuoteCacheEntry {
-  quote: SwapQuote;
-  timestamp: number;
-}
-
-export type QuoteMap = Map<string, QuoteCacheEntry>;
-
-interface UserAssetToken {
-  symbol: string;
-  quantity: string;
-  collection?: string;
-  category?: string;
-  type?: string;
-  additionalKey?: string;
-}
-
-interface UserAssetsResponse {
-  tokens?: UserAssetToken[];
-}
-
-export class BalanceSnapshot {
-  private readonly balances: Map<string, number>;
-  readonly fetchedAt: number;
-
-  constructor(balances: Map<string, number>, fetchedAt: number) {
-    this.balances = balances;
-    this.fetchedAt = fetchedAt;
-  }
-
-  getBalance(tokenClass: string): number {
-    return this.balances.get(tokenClass) ?? 0;
-  }
-}
-
-export function buildQuoteCacheKey(
-  inputTokenClass: string,
-  outputTokenClass: string,
-  inputAmount: number
-): string {
-  return `${inputTokenClass}::${outputTokenClass}::${inputAmount}`;
-}
-
-export interface SwapResult {
-  transactionHash: string;
-  inputAmount: number;
-  outputAmount: number;
-  actualPrice: number;
-  gasUsed: number;
-  timestamp: number;
-}
+export { BalanceSnapshot } from './balanceManager';
+export { buildQuoteCacheKey } from './quotes';
+export { createTokenClassKey } from './tokenRegistry';
+export type { QuoteCacheEntry, QuoteMap, SwapQuote, SwapResult, TokenInfo, TradingPair } from './types';
 
 export class GSwapAPI {
-  private gSwap: GSwap;
-  private signer: PrivateKeySigner;
-  private availableTokens: TokenInfo[] = [];
-  private tokensLoaded: boolean = false;
-  private latestQuoteMap: QuoteMap = new Map();
-  private balanceSnapshot: BalanceSnapshot | null = null;
+  private readonly gSwap: GSwap;
+  private readonly signer: PrivateKeySigner;
+  private readonly tokenRegistry: TokenRegistry;
+  private readonly balanceManager: BalanceManager;
   private readonly isMockMode: boolean;
-  private mockBalances: Map<string, number> | null = null;
+  private latestQuoteMap: QuoteMap = new Map();
 
   constructor() {
     this.signer = new PrivateKeySigner(config.privateKey);
     this.gSwap = new GSwap({
       signer: this.signer,
     });
+
     this.isMockMode = config.mockMode;
 
-    if (this.isMockMode) {
-      this.initializeMockBalances();
-    }
+    this.tokenRegistry = new TokenRegistry({
+      galaSwapApiUrl: config.galaSwapApiUrl,
+    });
+
+    this.balanceManager = new BalanceManager({
+      isMockMode: this.isMockMode,
+      balanceRefreshInterval: config.balanceRefreshInterval,
+      mockWalletBalances: config.mockWalletBalances,
+      fetchUserAssets: () => this.fetchUserAssets(),
+    });
   }
 
-  /**
-   * Get wallet address
-   */
   getWalletAddress(): string {
     return config.walletAddress;
   }
 
-  /**
-   * Load all available tokens from GalaSwap API at startup
-   */
   async loadAvailableTokens(): Promise<void> {
-    try {
-      console.log('🔄 Loading available tokens from GalaSwap API...');
-      
-      // Fetch all available tokens from GalaSwap API
-      const response = await fetch(`${config.galaSwapApiUrl}/user/token-list?search=&page=1&limit=100`);
-      const data = await response.json() as GalaSwapTokenListResponse;
-      
-      if (data.status === 200 && data.data && data.data.token) {
-        this.availableTokens = data.data.token.map(token => ({
-          symbol: token.symbol,
-          name: token.name,
-          decimals: parseInt(token.decimals),
-          tokenClass: token.compositeKey.replace(/\$/g, '|'),
-          price: 0, // Will be fetched from quotes
-          priceChange24h: 0
-        }));
-        
-        this.tokensLoaded = true;
-        console.log(`✅ Loaded ${this.availableTokens.length} available tokens from GalaSwap`);
-      } else {
-        throw new Error('Failed to load tokens from GalaSwap API');
-      }
-    } catch (error) {
-      console.error('❌ Failed to load available tokens:', error);
-      // Fallback to common tokens
-      this.availableTokens = [
-        { symbol: 'GALA', name: 'Gala', decimals: 8, tokenClass: 'GALA|Unit|none|none', price: 0, priceChange24h: 0 },
-        { symbol: 'GUSDC', name: 'Gala USD Coin', decimals: 6, tokenClass: 'GUSDC|Unit|none|none', price: 0, priceChange24h: 0 },
-        { symbol: 'GUSDT', name: 'Gala Tether', decimals: 6, tokenClass: 'GUSDT|Unit|none|none', price: 0, priceChange24h: 0 },
-        { symbol: 'GWETH', name: 'Gala Wrapped Ethereum', decimals: 18, tokenClass: 'GWETH|Unit|none|none', price: 0, priceChange24h: 0 },
-        { symbol: 'GWBTC', name: 'Gala Wrapped Bitcoin', decimals: 8, tokenClass: 'GWBTC|Unit|none|none', price: 0, priceChange24h: 0 }
-      ];
-      this.tokensLoaded = true;
-      console.log('⚠️  Using fallback token list');
-    }
+    await this.tokenRegistry.loadTokens();
   }
 
-  /**
-   * Get token information from cached token list by token class key
-   */
   async getTokenInfoByClassKey(tokenClassKey: string): Promise<TokenInfo | null> {
-    try {
-      // Ensure tokens are loaded
-      if (!this.tokensLoaded) {
-        await this.loadAvailableTokens();
-      }
-
-      // Find token in cached list by token class key
-      const token = this.availableTokens.find(t => 
-        t.tokenClass === tokenClassKey
-      );
-
-      return token || null;
-    } catch (error) {
-      console.error(`Failed to get token info for ${tokenClassKey}:`, error);
-      return null;
-    }
+    return this.tokenRegistry.getTokenInfoByClassKey(tokenClassKey);
   }
 
-  /**
-   * Get token information from cached token list by token data
-   */
   async getTokenInfoByData(tokenData: { collection: string; category: string; type: string; additionalKey: string }): Promise<TokenInfo | null> {
-    const tokenClassKey = this.createTokenClassKey(tokenData);
+    const tokenClassKey = createTokenClassKey(tokenData);
     return this.getTokenInfoByClassKey(tokenClassKey);
   }
 
-  /**
-   * Get token information from cached token list by symbol (backward compatibility)
-   */
   async getTokenInfo(symbol: string): Promise<TokenInfo | null> {
-    try {
-      // Ensure tokens are loaded
-      if (!this.tokensLoaded) {
-        await this.loadAvailableTokens();
-      }
-
-      // Find token in cached list by symbol (for backward compatibility)
-      const token = this.availableTokens.find(t => 
-        t.symbol.toUpperCase() === symbol.toUpperCase()
-      );
-
-      return token || null;
-    } catch (error) {
-      console.error(`Failed to get token info for ${symbol}:`, error);
-      return null;
-    }
+    return this.tokenRegistry.getTokenInfoBySymbol(symbol);
   }
 
-  /**
-   * Get all available tokens from cached list
-   */
   async getAvailableTokens(): Promise<TokenInfo[]> {
-    try {
-      // Ensure tokens are loaded
-      if (!this.tokensLoaded) {
-        await this.loadAvailableTokens();
-      }
-
-      return [...this.availableTokens]; // Return a copy to prevent external modification
-    } catch (error) {
-      console.error('Failed to get available tokens:', error);
-      return [];
-    }
+    return this.tokenRegistry.getAvailableTokens();
   }
 
-  /**
-   * Get trading pairs by checking which tokens can be swapped (GALA pairs only)
-   */
   async getTradingPairs(): Promise<TradingPair[]> {
     try {
       const tokens = await this.getAvailableTokens();
       const pairs: TradingPair[] = [];
       const quoteMap: QuoteMap = new Map();
 
-      // Find GALA token
       const galaToken = tokens.find(token => token.tokenClass === 'GALA|Unit|none|none');
       if (!galaToken) {
         console.warn('⚠️  GALA token not found in available tokens');
@@ -276,7 +100,7 @@ export class GSwapAPI {
           try {
             const [quoteAB, quoteBA] = await Promise.all([
               this.getQuote(galaToken.tokenClass, otherToken.tokenClass, 1),
-              this.getQuote(otherToken.tokenClass, galaToken.tokenClass, 1)
+              this.getQuote(otherToken.tokenClass, galaToken.tokenClass, 1),
             ]);
 
             const timestamp = Date.now();
@@ -284,14 +108,14 @@ export class GSwapAPI {
             if (quoteAB) {
               quoteMap.set(
                 buildQuoteCacheKey(galaToken.tokenClass, otherToken.tokenClass, quoteAB.inputAmount),
-                { quote: quoteAB, timestamp }
+                { quote: quoteAB, timestamp },
               );
             }
 
             if (quoteBA) {
               quoteMap.set(
                 buildQuoteCacheKey(otherToken.tokenClass, galaToken.tokenClass, quoteBA.inputAmount),
-                { quote: quoteBA, timestamp }
+                { quote: quoteBA, timestamp },
               );
             }
 
@@ -300,7 +124,7 @@ export class GSwapAPI {
                 tokenA: galaToken,
                 tokenB: otherToken,
                 tokenClassA: galaToken.tokenClass,
-                tokenClassB: otherToken.tokenClass
+                tokenClassB: otherToken.tokenClass,
               });
             } else {
               console.warn(`No liquidity for GALA <-> ${otherToken.symbol}`);
@@ -323,160 +147,37 @@ export class GSwapAPI {
   }
 
   getLatestQuoteMap(): QuoteMap {
-    return new Map(this.latestQuoteMap);
-  }
-
-  private isSnapshotExpired(snapshot: BalanceSnapshot): boolean {
-    if (config.balanceRefreshInterval === 0) {
-      return false;
-    }
-
-    return Date.now() - snapshot.fetchedAt >= config.balanceRefreshInterval;
-  }
-
-  private initializeMockBalances(): void {
-    this.mockBalances = new Map<string, number>();
-
-    for (const [tokenClass, quantity] of Object.entries(config.mockWalletBalances)) {
-      this.mockBalances.set(tokenClass, quantity);
-    }
-  }
-
-  private getMockBalances(): Map<string, number> {
-    if (!this.mockBalances) {
-      this.initializeMockBalances();
-    }
-
-    return this.mockBalances!;
-  }
-
-  private buildSnapshotFromMockBalances(): BalanceSnapshot {
-    const balances = new Map<string, number>();
-    const mockBalances = this.getMockBalances();
-
-    for (const [tokenClass, quantity] of mockBalances.entries()) {
-      balances.set(tokenClass, quantity);
-    }
-
-    return new BalanceSnapshot(balances, Date.now());
-  }
-
-  private buildMockAssetsResponse(): UserAssetsResponse {
-    const tokens: UserAssetToken[] = [];
-
-    for (const [tokenClass, quantity] of this.getMockBalances().entries()) {
-      const [collection = '', category = '', type = '', additionalKey = ''] = tokenClass.split('|');
-
-      tokens.push({
-        symbol: collection,
-        quantity: quantity.toString(),
-        collection,
-        category,
-        type,
-        additionalKey,
-      });
-    }
-
-    return { tokens };
-  }
-
-  private applyMockSwap(
-    inputTokenClass: string,
-    outputTokenClass: string,
-    inputAmount: number,
-    outputAmount: number
-  ): void {
-    const balances = this.getMockBalances();
-    const currentInput = balances.get(inputTokenClass) ?? 0;
-
-    if (currentInput < inputAmount) {
-      throw new Error(`Insufficient mock balance for ${inputTokenClass}`);
-    }
-
-    balances.set(inputTokenClass, currentInput - inputAmount);
-
-    const currentOutput = balances.get(outputTokenClass) ?? 0;
-    balances.set(outputTokenClass, currentOutput + outputAmount);
-
-    this.balanceSnapshot = this.buildSnapshotFromMockBalances();
-  }
-
-  private async buildBalanceSnapshot(): Promise<BalanceSnapshot> {
-    const userAssets = await this.fetchUserAssets();
-    const balances = new Map<string, number>();
-
-    const tokens = userAssets?.tokens ?? [];
-    for (const token of tokens) {
-      const tokenClass = stringifyTokenClassKey({
-        collection: token.collection ?? token.symbol,
-        category: token.category ?? 'Unit',
-        type: token.type ?? 'none',
-        additionalKey: token.additionalKey ?? 'none'
-      });
-
-      const quantity = parseFloat(token.quantity ?? '0');
-      if (!Number.isNaN(quantity)) {
-        balances.set(tokenClass, quantity);
-      }
-    }
-
-    return new BalanceSnapshot(balances, Date.now());
+    return cloneQuoteMap(this.latestQuoteMap);
   }
 
   async getBalanceSnapshot(forceRefresh: boolean = false): Promise<BalanceSnapshot> {
-    if (!forceRefresh && this.balanceSnapshot && !this.isSnapshotExpired(this.balanceSnapshot)) {
-      return this.balanceSnapshot;
-    }
-
-    try {
-      const snapshot = this.isMockMode
-        ? this.buildSnapshotFromMockBalances()
-        : await this.buildBalanceSnapshot();
-      this.balanceSnapshot = snapshot;
-      return snapshot;
-    } catch (error) {
-      console.error('Failed to refresh balance snapshot:', error);
-
-      if (this.balanceSnapshot) {
-        return this.balanceSnapshot;
-      }
-
-      const emptySnapshot = this.isMockMode
-        ? this.buildSnapshotFromMockBalances()
-        : new BalanceSnapshot(new Map(), Date.now());
-
-      this.balanceSnapshot = emptySnapshot;
-      return emptySnapshot;
-    }
+    return this.balanceManager.getSnapshot(forceRefresh);
   }
 
   async refreshBalanceSnapshot(): Promise<BalanceSnapshot> {
-    return this.getBalanceSnapshot(true);
+    return this.balanceManager.refreshSnapshot();
   }
 
-  /**
-   * Get a quote for swapping tokens
-   */
   async getQuote(
     inputTokenClass: string,
     outputTokenClass: string,
-    inputAmount: number
+    inputAmount: number,
   ): Promise<SwapQuote | null> {
     try {
       const quote = await this.gSwap.quoting.quoteExactInput(
         inputTokenClass,
         outputTokenClass,
-        inputAmount
+        inputAmount,
       );
 
       return {
         inputToken: inputTokenClass,
         outputToken: outputTokenClass,
-        inputAmount: inputAmount,
+        inputAmount,
         outputAmount: quote.outTokenAmount.toNumber(),
         priceImpact: quote.priceImpact ? quote.priceImpact.toNumber() : 0,
         feeTier: quote.feeTier,
-        route: []
+        route: [],
       };
     } catch (error) {
       console.error(`Failed to get quote for ${inputTokenClass} -> ${outputTokenClass}:`, error);
@@ -484,15 +185,12 @@ export class GSwapAPI {
     }
   }
 
-  /**
-   * Execute a swap
-   */
   async executeSwap(
     inputTokenClass: string,
     outputTokenClass: string,
     inputAmount: number,
     slippageTolerance: number = config.slippageTolerance,
-    providedQuote?: SwapQuote
+    providedQuote?: SwapQuote,
   ): Promise<SwapResult> {
     try {
       let quote = this.isQuoteValidForSwap(providedQuote, inputTokenClass, outputTokenClass, inputAmount)
@@ -508,48 +206,44 @@ export class GSwapAPI {
         throw new Error('Unable to get quote for swap');
       }
 
-      // Calculate minimum output with slippage tolerance
       const minOutputAmount = quote.outputAmount * (1 - slippageTolerance / 100);
+      const feeTier = Math.floor(quote.feeTier * 10000);
 
-      // Execute the swap
+      if (this.isMockMode) {
+        this.balanceManager.applyMockSwap(inputTokenClass, outputTokenClass, inputAmount, quote.outputAmount);
+
+        return {
+          transactionHash: `mock_tx_${Date.now()}`,
+          inputAmount,
+          outputAmount: quote.outputAmount,
+          actualPrice: quote.outputAmount / inputAmount,
+          gasUsed: 0,
+          timestamp: Date.now(),
+        };
+      }
+
       const swapParams = {
         exactIn: inputAmount,
         amountOutMinimum: minOutputAmount,
       };
 
-      // Convert fee tier to proper format (0.3% = 3000)
-      const feeTier = Math.floor(quote.feeTier * 10000);
-
-      if (this.isMockMode) {
-        this.applyMockSwap(inputTokenClass, outputTokenClass, inputAmount, quote.outputAmount);
-
-        return {
-          transactionHash: `mock_tx_${Date.now()}`,
-          inputAmount: inputAmount,
-          outputAmount: quote.outputAmount,
-          actualPrice: quote.outputAmount / inputAmount,
-          gasUsed: 0,
-          timestamp: Date.now()
-        };
-      }
-
-      const transaction = await this.gSwap.swaps.swap(
+      await this.gSwap.swaps.swap(
         inputTokenClass,
         outputTokenClass,
         feeTier,
         swapParams,
-        config.walletAddress
+        config.walletAddress,
       );
 
       await this.refreshBalanceSnapshot();
 
       return {
-        transactionHash: 'unknown', // Transaction hash not available in PendingTransaction
-        inputAmount: inputAmount,
+        transactionHash: 'unknown',
+        inputAmount,
         outputAmount: quote.outputAmount,
         actualPrice: quote.outputAmount / inputAmount,
-        gasUsed: 0, // Would need to parse from transaction receipt
-        timestamp: Date.now()
+        gasUsed: 0,
+        timestamp: Date.now(),
       };
     } catch (error) {
       console.error('Failed to execute swap:', error);
@@ -557,19 +251,103 @@ export class GSwapAPI {
     }
   }
 
-  private async fetchUserAssets(): Promise<UserAssetsResponse> {
-    if (this.isMockMode) {
-      return this.buildMockAssetsResponse();
+  async getCurrentPrice(inputTokenClass: string, outputTokenClass: string): Promise<number | null> {
+    try {
+      const quote = await this.getQuote(inputTokenClass, outputTokenClass, 1);
+      return quote ? quote.outputAmount : null;
+    } catch (error) {
+      console.error(`Failed to get current price for ${inputTokenClass} -> ${outputTokenClass}:`, error);
+      return null;
+    }
+  }
+
+  async isSwapProfitable(
+    inputTokenClass: string,
+    outputTokenClass: string,
+    inputAmount: number,
+    minProfitPercentage: number,
+  ): Promise<{ profitable: boolean; profitPercentage: number; quote: SwapQuote | null }> {
+    try {
+      const quote = await this.getQuote(inputTokenClass, outputTokenClass, inputAmount);
+
+      if (!quote) {
+        return { profitable: false, profitPercentage: 0, quote: null };
+      }
+
+      const profitPercentage = ((quote.outputAmount - inputAmount) / inputAmount) * 100;
+      const profitable = profitPercentage >= minProfitPercentage;
+
+      return { profitable, profitPercentage, quote };
+    } catch (error) {
+      console.error('Failed to check swap profitability:', error);
+      return { profitable: false, profitPercentage: 0, quote: null };
+    }
+  }
+
+  async getTokenBalance(tokenClass: string): Promise<number> {
+    try {
+      const snapshot = await this.getBalanceSnapshot();
+      return snapshot.getBalance(tokenClass);
+    } catch (error) {
+      console.error(`Failed to get balance for ${tokenClass}:`, error);
+      return 0;
+    }
+  }
+
+  async checkTradingFunds(requiredAmount: number, tokenClass: string, snapshot?: BalanceSnapshot): Promise<{
+    hasFunds: boolean;
+    currentBalance: number;
+    shortfall: number;
+  }> {
+    return this.balanceManager.checkTradingFunds(requiredAmount, tokenClass, snapshot);
+  }
+
+  isTokenAvailableByClassKey(tokenClassKey: string): boolean {
+    if (!this.tokenRegistry.isLoaded()) {
+      console.warn('⚠️  Token list not loaded yet, cannot validate token');
+      return false;
     }
 
-    return await this.gSwap.assets.getUserAssets(config.walletAddress, 1, 100) as UserAssetsResponse;
+    return this.tokenRegistry.isTokenAvailableByClassKey(tokenClassKey);
+  }
+
+  isTokenAvailableByData(tokenData: { collection: string; category: string; type: string; additionalKey: string }): boolean {
+    const tokenClassKey = createTokenClassKey(tokenData);
+    return this.isTokenAvailableByClassKey(tokenClassKey);
+  }
+
+  isTokenAvailable(tokenSymbol: string): boolean {
+    if (!this.tokenRegistry.isLoaded()) {
+      console.warn('⚠️  Token list not loaded yet, cannot validate token');
+      return false;
+    }
+
+    return this.tokenRegistry.isTokenAvailableBySymbol(tokenSymbol);
+  }
+
+  getTokenByClassKey(tokenClassKey: string): TokenInfo | null {
+    return this.tokenRegistry.getTokenByClassKey(tokenClassKey);
+  }
+
+  createTokenClassKey(tokenData: { collection: string; category: string; type: string; additionalKey: string }): string {
+    return createTokenClassKey(tokenData);
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      const quote = await this.getQuote('GALA|Unit|none|none', 'GUSDC|Unit|none|none', 1);
+      return quote !== null;
+    } catch (error) {
+      console.error('gSwap connection test failed:', error);
+      return false;
+    }
   }
 
   private isQuoteValidForSwap(
     quote: SwapQuote | undefined,
     inputTokenClass: string,
     outputTokenClass: string,
-    inputAmount: number
+    inputAmount: number,
   ): quote is SwapQuote {
     if (!quote) {
       return false;
@@ -587,159 +365,11 @@ export class GSwapAPI {
     return amountMatches && quote.outputAmount > 0;
   }
 
-  /**
-   * Get current price for a token pair
-   */
-  async getCurrentPrice(inputTokenClass: string, outputTokenClass: string): Promise<number | null> {
-    try {
-      const quote = await this.getQuote(inputTokenClass, outputTokenClass, 1);
-      return quote ? quote.outputAmount : null;
-    } catch (error) {
-      console.error(`Failed to get current price for ${inputTokenClass} -> ${outputTokenClass}:`, error);
-      return null;
-    }
-  }
-
-  /**
-   * Check if a swap is profitable after fees
-   */
-  async isSwapProfitable(
-    inputTokenClass: string,
-    outputTokenClass: string,
-    inputAmount: number,
-    minProfitPercentage: number
-  ): Promise<{ profitable: boolean; profitPercentage: number; quote: SwapQuote | null }> {
-    try {
-      const quote = await this.getQuote(inputTokenClass, outputTokenClass, inputAmount);
-      
-      if (!quote) {
-        return { profitable: false, profitPercentage: 0, quote: null };
-      }
-
-      // Calculate profit percentage
-      const profitPercentage = ((quote.outputAmount - inputAmount) / inputAmount) * 100;
-      const profitable = profitPercentage >= minProfitPercentage;
-
-      return { profitable, profitPercentage, quote };
-    } catch (error) {
-      console.error('Failed to check swap profitability:', error);
-      return { profitable: false, profitPercentage: 0, quote: null };
-    }
-  }
-
-  /**
-   * Get wallet balance for a token using gSwap SDK
-   */
-  async getTokenBalance(tokenClass: string): Promise<number> {
-    try {
-      const snapshot = await this.getBalanceSnapshot();
-      return snapshot.getBalance(tokenClass);
-    } catch (error) {
-      console.error(`Failed to get balance for ${tokenClass}:`, error);
-      return 0;
-    }
-  }
-
-  /**
-   * Check if wallet has sufficient balance for trading
-   */
-  async checkTradingFunds(requiredAmount: number, tokenClass: string, snapshot?: BalanceSnapshot): Promise<{
-    hasFunds: boolean;
-    currentBalance: number;
-    shortfall: number;
-  }> {
-    try {
-      const balanceSnapshot = snapshot ?? await this.getBalanceSnapshot();
-      const currentBalance = balanceSnapshot.getBalance(tokenClass);
-      const shortfall = Math.max(0, requiredAmount - currentBalance);
-
-      return {
-        hasFunds: currentBalance >= requiredAmount,
-        currentBalance,
-        shortfall
-      };
-    } catch (error) {
-      console.error(`Failed to check trading funds for ${tokenClass}:`, error);
-      return {
-        hasFunds: false,
-        currentBalance: 0,
-        shortfall: requiredAmount
-      };
-    }
-  }
-
-  /**
-   * Validate if a token is available on GalaSwap by token class key
-   */
-  isTokenAvailableByClassKey(tokenClassKey: string): boolean {
-    if (!this.tokensLoaded) {
-      console.warn('⚠️  Token list not loaded yet, cannot validate token');
-      return false;
+  private async fetchUserAssets(): Promise<UserAssetsResponse> {
+    if (this.isMockMode) {
+      return { tokens: [] };
     }
 
-    return this.availableTokens.some(token => 
-      token.tokenClass === tokenClassKey
-    );
-  }
-
-  /**
-   * Validate if a token is available on GalaSwap by token data
-   */
-  isTokenAvailableByData(tokenData: { collection: string; category: string; type: string; additionalKey: string }): boolean {
-    const tokenClassKey = this.createTokenClassKey(tokenData);
-    return this.isTokenAvailableByClassKey(tokenClassKey);
-  }
-
-  /**
-   * Validate if a token is available on GalaSwap (backward compatibility)
-   */
-  isTokenAvailable(tokenSymbol: string): boolean {
-    if (!this.tokensLoaded) {
-      console.warn('⚠️  Token list not loaded yet, cannot validate token');
-      return false;
-    }
-
-    return this.availableTokens.some(token => 
-      token.symbol.toUpperCase() === tokenSymbol.toUpperCase()
-    );
-  }
-
-  /**
-   * Create token class key from block token data
-   */
-  createTokenClassKey(tokenData: { collection: string; category: string; type: string; additionalKey: string }): string {
-    return stringifyTokenClassKey({
-      collection: tokenData.collection,
-      category: tokenData.category,
-      type: tokenData.type,
-      additionalKey: tokenData.additionalKey
-    });
-  }
-
-  /**
-   * Get token info by token class key (for Kafka block validation)
-   */
-  getTokenByClassKey(tokenClassKey: string): TokenInfo | null {
-    if (!this.tokensLoaded) {
-      return null;
-    }
-
-    return this.availableTokens.find(token => 
-      token.tokenClass === tokenClassKey
-    ) || null;
-  }
-
-  /**
-   * Test connection to gSwap
-   */
-  async testConnection(): Promise<boolean> {
-    try {
-      // Try to get a simple quote to test connection
-      const quote = await this.getQuote('GALA|Unit|none|none', 'GUSDC|Unit|none|none', 1);
-      return quote !== null;
-    } catch (error) {
-      console.error('gSwap connection test failed:', error);
-      return false;
-    }
+    return await this.gSwap.assets.getUserAssets(config.walletAddress, 1, 100) as UserAssetsResponse;
   }
 }

--- a/src/api/quotes.ts
+++ b/src/api/quotes.ts
@@ -1,0 +1,13 @@
+import type { QuoteMap } from './types';
+
+export function buildQuoteCacheKey(
+  inputTokenClass: string,
+  outputTokenClass: string,
+  inputAmount: number
+): string {
+  return `${inputTokenClass}::${outputTokenClass}::${inputAmount}`;
+}
+
+export function cloneQuoteMap(quoteMap: QuoteMap): QuoteMap {
+  return new Map(quoteMap);
+}

--- a/src/api/tokenRegistry.ts
+++ b/src/api/tokenRegistry.ts
@@ -1,0 +1,135 @@
+import { stringifyTokenClassKey } from '@gala-chain/gswap-sdk';
+import type {
+  GalaSwapToken,
+  GalaSwapTokenListResponse,
+  TokenInfo
+} from './types';
+
+const FALLBACK_TOKENS: TokenInfo[] = [
+  { symbol: 'GALA', name: 'Gala', decimals: 8, tokenClass: 'GALA|Unit|none|none', price: 0, priceChange24h: 0 },
+  { symbol: 'GUSDC', name: 'Gala USD Coin', decimals: 6, tokenClass: 'GUSDC|Unit|none|none', price: 0, priceChange24h: 0 },
+  { symbol: 'GUSDT', name: 'Gala Tether', decimals: 6, tokenClass: 'GUSDT|Unit|none|none', price: 0, priceChange24h: 0 },
+  { symbol: 'GWETH', name: 'Gala Wrapped Ethereum', decimals: 18, tokenClass: 'GWETH|Unit|none|none', price: 0, priceChange24h: 0 },
+  { symbol: 'GWBTC', name: 'Gala Wrapped Bitcoin', decimals: 8, tokenClass: 'GWBTC|Unit|none|none', price: 0, priceChange24h: 0 }
+];
+
+export interface TokenRegistryOptions {
+  galaSwapApiUrl: string;
+  fetchFn?: typeof fetch;
+}
+
+export class TokenRegistry {
+  private readonly fetchFn: typeof fetch;
+  private availableTokens: TokenInfo[] = [];
+  private tokensLoaded = false;
+
+  constructor(private readonly options: TokenRegistryOptions) {
+    this.fetchFn = options.fetchFn ?? fetch;
+  }
+
+  isLoaded(): boolean {
+    return this.tokensLoaded;
+  }
+
+  async loadTokens(): Promise<void> {
+    if (this.tokensLoaded) {
+      return;
+    }
+
+    try {
+      console.log('🔄 Loading available tokens from GalaSwap API...');
+      const data = await this.fetchTokenList();
+
+      if (data.status === 200 && data.data?.token) {
+        this.availableTokens = data.data.token.map(this.transformToken);
+        console.log(`✅ Loaded ${this.availableTokens.length} available tokens from GalaSwap`);
+      } else {
+        throw new Error('Failed to load tokens from GalaSwap API');
+      }
+    } catch (error) {
+      console.error('❌ Failed to load available tokens:', error);
+      this.availableTokens = [...FALLBACK_TOKENS];
+      console.log('⚠️  Using fallback token list');
+    } finally {
+      this.tokensLoaded = true;
+    }
+  }
+
+  async getAvailableTokens(): Promise<TokenInfo[]> {
+    if (!this.tokensLoaded) {
+      await this.loadTokens();
+    }
+
+    return [...this.availableTokens];
+  }
+
+  async getTokenInfoByClassKey(tokenClassKey: string): Promise<TokenInfo | null> {
+    if (!this.tokensLoaded) {
+      await this.loadTokens();
+    }
+
+    return this.availableTokens.find(token => token.tokenClass === tokenClassKey) ?? null;
+  }
+
+  async getTokenInfoBySymbol(symbol: string): Promise<TokenInfo | null> {
+    if (!this.tokensLoaded) {
+      await this.loadTokens();
+    }
+
+    return this.availableTokens.find(token => token.symbol.toUpperCase() === symbol.toUpperCase()) ?? null;
+  }
+
+  getTokenByClassKey(tokenClassKey: string): TokenInfo | null {
+    if (!this.tokensLoaded) {
+      return null;
+    }
+
+    return this.availableTokens.find(token => token.tokenClass === tokenClassKey) ?? null;
+  }
+
+  isTokenAvailableByClassKey(tokenClassKey: string): boolean {
+    if (!this.tokensLoaded) {
+      return false;
+    }
+
+    return this.availableTokens.some(token => token.tokenClass === tokenClassKey);
+  }
+
+  isTokenAvailableBySymbol(symbol: string): boolean {
+    if (!this.tokensLoaded) {
+      return false;
+    }
+
+    return this.availableTokens.some(token => token.symbol.toUpperCase() === symbol.toUpperCase());
+  }
+
+  private async fetchTokenList(): Promise<GalaSwapTokenListResponse> {
+    const response = await this.fetchFn(`${this.options.galaSwapApiUrl}/user/token-list?search=&page=1&limit=100`);
+    return await response.json() as GalaSwapTokenListResponse;
+  }
+
+  private transformToken(token: GalaSwapToken): TokenInfo {
+    return {
+      symbol: token.symbol,
+      name: token.name,
+      decimals: parseInt(token.decimals, 10),
+      tokenClass: token.compositeKey.replace(/\$/g, '|'),
+      price: 0,
+      priceChange24h: 0,
+    };
+  }
+}
+
+export function createTokenClassKey(tokenData: {
+  collection: string;
+  category: string;
+  type: string;
+  additionalKey: string;
+}): string {
+  return stringifyTokenClassKey({
+    collection: tokenData.collection,
+    category: tokenData.category,
+    type: tokenData.type,
+    additionalKey: tokenData.additionalKey,
+  });
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,79 @@
+export interface GalaSwapToken {
+  collection: string;
+  category: string;
+  type: string;
+  additionalKey: string;
+  decimals: string;
+  quantity: string;
+  compositeKey: string;
+  image: string;
+  name: string;
+  symbol: string;
+  description: string;
+  verify: boolean;
+}
+
+export interface GalaSwapTokenListResponse {
+  status: number;
+  error: boolean;
+  message: string;
+  data: {
+    token: GalaSwapToken[];
+    count: number;
+  };
+}
+
+export interface TokenInfo {
+  symbol: string;
+  name: string;
+  decimals: number;
+  tokenClass: string; // Format: "SYMBOL|Unit|none|none"
+  price: number;
+  priceChange24h: number;
+}
+
+export interface TradingPair {
+  tokenA: TokenInfo;
+  tokenB: TokenInfo;
+  tokenClassA: string;
+  tokenClassB: string;
+}
+
+export interface SwapQuote {
+  inputToken: string;
+  outputToken: string;
+  inputAmount: number;
+  outputAmount: number;
+  priceImpact: number;
+  feeTier: number;
+  route: string[];
+}
+
+export interface QuoteCacheEntry {
+  quote: SwapQuote;
+  timestamp: number;
+}
+
+export type QuoteMap = Map<string, QuoteCacheEntry>;
+
+export interface UserAssetToken {
+  symbol: string;
+  quantity: string;
+  collection?: string;
+  category?: string;
+  type?: string;
+  additionalKey?: string;
+}
+
+export interface UserAssetsResponse {
+  tokens?: UserAssetToken[];
+}
+
+export interface SwapResult {
+  transactionHash: string;
+  inputAmount: number;
+  outputAmount: number;
+  actualPrice: number;
+  gasUsed: number;
+  timestamp: number;
+}


### PR DESCRIPTION
## Summary
- extract shared gSwap types, token registry logic, balance snapshot management, and quote cache helpers into focused modules for reuse
- refactor the GSwapAPI class to lean on the new helpers, reducing state management complexity while keeping its public surface intact

## Testing
- `npm test` *(fails: jest command is unavailable in the environment even after npm install)*
- `npm run build` *(fails: tsc cannot resolve various @types packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcf3c6b4c8328a9b4c9788e0ab074