### PR TITLE
Simplify arbitrage detection and trade execution

### DIFF
--- a/src/strategies/arbitrage.ts
+++ b/src/strategies/arbitrage.ts
@@ -1,7 +1,16 @@
-import { GSwapAPI, TradingPair, SwapQuote, TokenInfo, QuoteMap, buildQuoteCacheKey, BalanceSnapshot } from '../api/gswap';
+import {
+  BalanceSnapshot,
+  GSwapAPI,
+  QuoteMap,
+  SwapQuote,
+  TradingPair,
+  buildQuoteCacheKey,
+} from '../api/gswap';
 import { config } from '../config';
 
 const QUOTE_CACHE_TTL_MS = 30_000;
+const TEST_TRADE_AMOUNT = 1;
+const GALA_TOKEN_CLASS = 'GALA|Unit|none|none';
 
 async function getQuoteFromCacheOrApi(
   quoteMap: QuoteMap | undefined,
@@ -14,9 +23,7 @@ async function getQuoteFromCacheOrApi(
 
   if (quoteMap) {
     const cached = quoteMap.get(cacheKey);
-    const now = Date.now();
-
-    if (cached && now - cached.timestamp <= QUOTE_CACHE_TTL_MS && cached.quote.inputAmount === inputAmount) {
+    if (cached && Date.now() - cached.timestamp <= QUOTE_CACHE_TTL_MS) {
       return cached.quote;
     }
   }
@@ -47,7 +54,6 @@ export interface ArbitrageOpportunity {
   currentBalance: number;
   shortfall: number;
   timestamp: number;
-  // Enhanced properties for real-time analysis
   currentMarketPrice?: number;
   priceDiscrepancy?: number;
   confidence?: number;
@@ -77,637 +83,160 @@ export interface SwapData {
   uniqueId: string;
 }
 
-export interface ArbitrageStrategy {
-  name: string;
-  description: string;
-  detectOpportunitiesForSwap(swapData: SwapData, currentPrice: number, api: GSwapAPI): Promise<ArbitrageOpportunity[]>;
-  detectOpportunities?(pairs: TradingPair[], api: GSwapAPI, quoteMap: QuoteMap): Promise<ArbitrageOpportunity[]>;
-}
-
-export type ArbitrageStrategyConstructor = new (balanceSnapshot: BalanceSnapshot) => ArbitrageStrategy;
-
-export class CrossPairArbitrageStrategy implements ArbitrageStrategy {
-  name = 'Cross-Pair Arbitrage';
-  description = 'Detects arbitrage opportunities between different trading pairs for the same token';
-
-  constructor(private readonly balanceSnapshot: BalanceSnapshot) {}
-
-  async detectOpportunitiesForSwap(
-    swapData: SwapData,
-    currentPrice: number,
-    api: GSwapAPI
-  ): Promise<ArbitrageOpportunity[]> {
-    const opportunities: ArbitrageOpportunity[] = [];
-    
-    // Get token class keys for the swap
-    const tokenInClassKey = api.createTokenClassKey(swapData.tokenIn);
-    const tokenOutClassKey = api.createTokenClassKey(swapData.tokenOut);
-
-    
-    // Only analyze if GALA is involved
-    const GALA_TOKEN_CLASS = 'GALA|Unit|none|none';
-    if (tokenInClassKey !== GALA_TOKEN_CLASS && tokenOutClassKey !== GALA_TOKEN_CLASS) {
-      return opportunities;
-    }
-    
-    // Get all available tokens to find related pairs
-    const availableTokens = await api.getAvailableTokens();
-    const galaToken = availableTokens.find(t => t.tokenClass === GALA_TOKEN_CLASS);
-    
-    if (!galaToken) {
-      return opportunities;
-    }
-    
-    // Find tokens that could form triangular arbitrage opportunities
-    const relatedTokens = this.findRelatedTokensForArbitrage(swapData, availableTokens, api);
-    
-    // Analyze triangular arbitrage opportunities
-    for (const relatedToken of relatedTokens) {
-      const opportunity = await this.analyzeTriangularArbitrage(
-        swapData, 
-        galaToken, 
-        relatedToken, 
-        currentPrice, 
-        api
-      );
-      
-      if (opportunity) {
-        opportunities.push(opportunity);
-      }
-    }
-    
-    return opportunities.sort((a, b) => b.profitPercentage - a.profitPercentage);
-  }
-
-  // Backward compatibility method
-  async detectOpportunities(
-    pairs: TradingPair[],
-    api: GSwapAPI,
-    quoteMap: QuoteMap
-  ): Promise<ArbitrageOpportunity[]> {
-    const opportunities: ArbitrageOpportunity[] = [];
-    
-    // Filter pairs to only include GALA pairs
-    const galaPairs = pairs.filter(pair => 
-      pair.tokenClassA === 'GALA|Unit|none|none' || pair.tokenClassB === 'GALA|Unit|none|none'
-    );
-    
-    // Group pairs by tokens to find cross-pair opportunities
-    const pairsByToken = this.groupPairsByToken(galaPairs);
-    
-    for (const [token, tokenPairs] of pairsByToken.entries()) {
-      if (tokenPairs.length < 2) continue;
-      
-      // Compare all pairs for this token
-      for (let i = 0; i < tokenPairs.length; i++) {
-        for (let j = i + 1; j < tokenPairs.length; j++) {
-          const pairA = tokenPairs[i];
-          const pairB = tokenPairs[j];
-          
-          const opportunity = await this.analyzePairArbitrage(pairA, pairB, api, quoteMap);
-          if (opportunity) {
-            opportunities.push(opportunity);
-          }
-        }
-      }
-    }
-    
-    return opportunities.sort((a, b) => b.profitPercentage - a.profitPercentage);
-  }
-
-  private groupPairsByToken(pairs: TradingPair[]): Map<string, TradingPair[]> {
-    const grouped = new Map<string, TradingPair[]>();
-    
-    for (const pair of pairs) {
-      // Group by both tokens in the pair
-      const tokenA = pair.tokenA.symbol;
-      const tokenB = pair.tokenB.symbol;
-      
-      if (!grouped.has(tokenA)) {
-        grouped.set(tokenA, []);
-      }
-      if (!grouped.has(tokenB)) {
-        grouped.set(tokenB, []);
-      }
-      
-      grouped.get(tokenA)!.push(pair);
-      grouped.get(tokenB)!.push(pair);
-    }
-    
-    return grouped;
-  }
-
-  private findRelatedTokensForArbitrage(swapData: SwapData, availableTokens: TokenInfo[], api: GSwapAPI): TokenInfo[] {
-    const GALA_TOKEN_CLASS = 'GALA|Unit|none|none';
-    const tokenInClassKey = api.createTokenClassKey(swapData.tokenIn);
-    const tokenOutClassKey = api.createTokenClassKey(swapData.tokenOut);
-    
-    // Find tokens that are NOT part of the current swap for triangular arbitrage
-    const commonTokens = availableTokens.filter(token => 
-      token.tokenClass !== GALA_TOKEN_CLASS && 
-      token.tokenClass !== tokenInClassKey &&
-      token.tokenClass !== tokenOutClassKey &&
-      (token.symbol === 'GUSDT' || token.symbol === 'GWETH' || token.symbol === 'GWBTC')
-    );
-    
-    return commonTokens.slice(0, 3); // Limit to 3 most common tokens for speed
-  }
-
-  private async analyzeTriangularArbitrage(
-    swapData: SwapData,
-    galaToken: TokenInfo,
-    relatedToken: TokenInfo,
-    currentPrice: number,
-    api: GSwapAPI
-  ): Promise<ArbitrageOpportunity | null> {
-    try {
-      const tokenInClassKey = api.createTokenClassKey(swapData.tokenIn);
-      const tokenOutClassKey = api.createTokenClassKey(swapData.tokenOut);
-      const GALA_TOKEN_CLASS = 'GALA|Unit|none|none';
-      
-      let path1: string, path2: string, path3: string;
-      let token1ClassKey: string, token2ClassKey: string, token3ClassKey: string;
-      
-      if (tokenInClassKey === GALA_TOKEN_CLASS) {
-        // GALA -> TOKEN swap, look for GALA -> TOKEN -> RELATED -> GALA triangular path
-        path1 = `${swapData.tokenIn.collection} -> ${swapData.tokenOut.collection}`;
-        path2 = `${swapData.tokenOut.collection} -> ${relatedToken.symbol}`;
-        path3 = `${relatedToken.symbol} -> ${swapData.tokenIn.collection}`;
-        token1ClassKey = tokenInClassKey;
-        token2ClassKey = tokenOutClassKey;
-        token3ClassKey = relatedToken.tokenClass;
-      } else {
-        // TOKEN -> GALA swap, look for TOKEN -> GALA -> RELATED -> TOKEN triangular path
-        path1 = `${swapData.tokenIn.collection} -> ${swapData.tokenOut.collection}`;
-        path2 = `${swapData.tokenOut.collection} -> ${relatedToken.symbol}`;
-        path3 = `${relatedToken.symbol} -> ${swapData.tokenIn.collection}`;
-        token1ClassKey = tokenInClassKey;
-        token2ClassKey = tokenOutClassKey;
-        token3ClassKey = relatedToken.tokenClass;
-      }
-      
-      // Get quotes for the triangular path
-      const testAmount = 1;
-      const quote1 = await api.getQuote(token1ClassKey, token2ClassKey, testAmount);
-      const quote2 = await api.getQuote(token2ClassKey, token3ClassKey, testAmount);
-      const quote3 = await api.getQuote(token3ClassKey, token1ClassKey, testAmount);
-      
-      if (!quote1 || !quote2 || !quote3) return null;
-      
-      // Calculate if the triangular path is profitable
-      const rate1 = quote1.outputAmount / quote1.inputAmount;
-      const rate2 = quote2.outputAmount / quote2.inputAmount;
-      const rate3 = quote3.outputAmount / quote3.inputAmount;
-      
-      const finalAmount = testAmount * rate1 * rate2 * rate3;
-      const profitPercentage = ((finalAmount - testAmount) / testAmount) * 100;
-      
-      if (profitPercentage < config.minProfitThreshold) return null;
-      
-      // Check if we have sufficient funds
-      const fundsCheck = await api.checkTradingFunds(config.maxTradeAmount, token1ClassKey, this.balanceSnapshot);
-      
-      return {
-        id: `triangular-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-        tokenA: swapData.tokenIn.collection,
-        tokenB: relatedToken.symbol,
-        tokenClassA: token1ClassKey,
-        tokenClassB: token3ClassKey,
-        buyPrice: rate1 * rate2,
-        sellPrice: 1 / rate3,
-        profitPercentage,
-        estimatedProfit: (profitPercentage / 100) * config.maxTradeAmount,
-        maxTradeAmount: config.maxTradeAmount,
-        buyQuote: quote1,
-        sellQuote: quote3,
-        hasFunds: fundsCheck.hasFunds,
-        currentBalance: fundsCheck.currentBalance,
-        shortfall: fundsCheck.shortfall,
-        timestamp: Date.now(),
-        currentMarketPrice: currentPrice,
-        priceDiscrepancy: Math.abs(currentPrice - (rate1 * rate2)) / currentPrice * 100,
-        confidence: profitPercentage
-      };
-    } catch (error) {
-      console.error('Error analyzing triangular arbitrage:', error);
-      return null;
-    }
-  }
-
-  private async analyzePairArbitrage(
-    pairA: TradingPair,
-    pairB: TradingPair,
-    api: GSwapAPI,
-    quoteMap: QuoteMap
-  ): Promise<ArbitrageOpportunity | null> {
-    try {
-      // Find common token between the pairs
-      const commonToken = this.findCommonToken(pairA, pairB);
-      if (!commonToken) return null;
-
-      // Get quotes for both directions
-      const testAmount = 1; // Test with 1 unit
-      
-      // Get quotes for A -> common token
-      const quoteA1 = await getQuoteFromCacheOrApi(quoteMap, api, pairA.tokenClassA, pairA.tokenClassB, testAmount);
-      const quoteA2 = await getQuoteFromCacheOrApi(quoteMap, api, pairA.tokenClassB, pairA.tokenClassA, testAmount);
-
-      // Get quotes for B -> common token
-      const quoteB1 = await getQuoteFromCacheOrApi(quoteMap, api, pairB.tokenClassA, pairB.tokenClassB, testAmount);
-      const quoteB2 = await getQuoteFromCacheOrApi(quoteMap, api, pairB.tokenClassB, pairB.tokenClassA, testAmount);
-
-      if (!quoteA1 || !quoteA2 || !quoteB1 || !quoteB2) return null;
-
-      // Calculate exchange rates
-      const rateA1 = quoteA1.outputAmount / quoteA1.inputAmount;
-      const rateA2 = quoteA2.outputAmount / quoteA2.inputAmount;
-      const rateB1 = quoteB1.outputAmount / quoteB1.inputAmount;
-      const rateB2 = quoteB2.outputAmount / quoteB2.inputAmount;
-
-      // Look for arbitrage opportunities
-      let bestOpportunity: ArbitrageOpportunity | null = null;
-
-      // Check A1 -> B2 arbitrage
-      if (rateA1 > 0 && rateB2 > 0) {
-        const profitPercentage = ((rateA1 - rateB2) / rateB2) * 100;
-        if (profitPercentage > config.minProfitThreshold) {
-          const opportunity = await this.createOpportunity(
-            pairA, pairB, commonToken,
-            rateA1, rateB2, profitPercentage,
-            quoteA1, quoteB2, api
-          );
-          if (opportunity !== null && (!bestOpportunity || (opportunity as ArbitrageOpportunity).profitPercentage > (bestOpportunity as ArbitrageOpportunity).profitPercentage)) {
-            bestOpportunity = opportunity;
-          }
-        }
-      }
-
-      // Check B1 -> A2 arbitrage
-      if (rateB1 > 0 && rateA2 > 0) {
-        const profitPercentage = ((rateB1 - rateA2) / rateA2) * 100;
-        if (profitPercentage > config.minProfitThreshold) {
-          const opportunity = await this.createOpportunity(
-            pairB, pairA, commonToken,
-            rateB1, rateA2, profitPercentage,
-            quoteB1, quoteA2, api
-          );
-          if (opportunity !== null && (!bestOpportunity || (opportunity as ArbitrageOpportunity).profitPercentage > (bestOpportunity as ArbitrageOpportunity).profitPercentage)) {
-            bestOpportunity = opportunity;
-          }
-        }
-      }
-
-      return bestOpportunity;
-    } catch (error) {
-      console.error('Error analyzing pair arbitrage:', error);
-      return null;
-    }
-  }
-
-  private findCommonToken(pairA: TradingPair, pairB: TradingPair): string | null {
-    const tokensA = [pairA.tokenA.symbol, pairA.tokenB.symbol];
-    const tokensB = [pairB.tokenA.symbol, pairB.tokenB.symbol];
-    
-    for (const token of tokensA) {
-      if (tokensB.includes(token)) {
-        return token;
-      }
-    }
-    
-    return null;
-  }
-
-  private async createOpportunity(
-    buyPair: TradingPair,
-    sellPair: TradingPair,
-    commonToken: string,
-    buyRate: number,
-    sellRate: number,
-    profitPercentage: number,
-    buyQuote: SwapQuote,
-    sellQuote: SwapQuote,
-    api: GSwapAPI
-  ): Promise<ArbitrageOpportunity | null> {
-    try {
-      // Calculate maximum trade amount based on available liquidity
-      const maxTradeAmount = Math.min(
-        config.maxTradeAmount,
-        buyQuote.inputAmount * 10, // Simple liquidity estimate
-        sellQuote.inputAmount * 10
-      );
-
-      if (maxTradeAmount <= 0) return null;
-
-      const estimatedProfit = (sellRate - buyRate) * maxTradeAmount;
-
-      // Check if we have sufficient funds for trading
-      const fundsCheck = await api.checkTradingFunds(maxTradeAmount, buyPair.tokenClassA, this.balanceSnapshot);
-
-      return {
-        id: `arb-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-        tokenA: buyPair.tokenA.symbol,
-        tokenB: sellPair.tokenA.symbol,
-        tokenClassA: buyPair.tokenClassA,
-        tokenClassB: sellPair.tokenClassA,
-        buyPrice: buyRate,
-        sellPrice: sellRate,
-        profitPercentage,
-        estimatedProfit,
-        maxTradeAmount,
-        buyQuote,
-        sellQuote,
-        hasFunds: fundsCheck.hasFunds,
-        currentBalance: fundsCheck.currentBalance,
-        shortfall: fundsCheck.shortfall,
-        timestamp: Date.now()
-      };
-    } catch (error) {
-      console.error('Error creating opportunity:', error);
-      return null;
-    }
-  }
-}
-
-export class DirectArbitrageStrategy implements ArbitrageStrategy {
-  name = 'Direct Arbitrage';
-  description = 'Detects arbitrage opportunities within the same trading pair (bid-ask spread)';
-
-  constructor(private readonly balanceSnapshot: BalanceSnapshot) {}
-
-  async detectOpportunitiesForSwap(
-    swapData: SwapData,
-    currentPrice: number,
-    api: GSwapAPI
-  ): Promise<ArbitrageOpportunity[]> {
-    const opportunities: ArbitrageOpportunity[] = [];
-    
-    // Get token class keys for the swap
-    const tokenInClassKey = api.createTokenClassKey(swapData.tokenIn);
-    const tokenOutClassKey = api.createTokenClassKey(swapData.tokenOut);
-    
-    // Only analyze if GALA is involved
-    const GALA_TOKEN_CLASS = 'GALA|Unit|none|none';
-    if (tokenInClassKey !== GALA_TOKEN_CLASS && tokenOutClassKey !== GALA_TOKEN_CLASS) {
-      return opportunities;
-    }
-    
-    try {
-      const opportunity = await this.analyzeDirectArbitrageForSwap(swapData, currentPrice, api);
-      if (opportunity) {
-        opportunities.push(opportunity);
-      }
-    } catch (error) {
-      console.error(`Error analyzing direct arbitrage for ${swapData.tokenIn.collection}-${swapData.tokenOut.collection}:`, error);
-    }
-    
-    return opportunities.sort((a, b) => b.profitPercentage - a.profitPercentage);
-  }
-
-  // Backward compatibility method
-  async detectOpportunities(
-    pairs: TradingPair[],
-    api: GSwapAPI,
-    quoteMap: QuoteMap
-  ): Promise<ArbitrageOpportunity[]> {
-    const opportunities: ArbitrageOpportunity[] = [];
-    
-    // Filter pairs to only include GALA pairs
-    const galaPairs = pairs.filter(pair => 
-      pair.tokenClassA === 'GALA|Unit|none|none' || pair.tokenClassB === 'GALA|Unit|none|none'
-    );
-    
-    for (const pair of galaPairs) {
-      try {
-        const opportunity = await this.analyzeDirectArbitrage(pair, api, quoteMap);
-        if (opportunity) {
-          opportunities.push(opportunity);
-        }
-      } catch (error) {
-        console.error(`Error analyzing direct arbitrage for ${pair.tokenA.symbol}-${pair.tokenB.symbol}:`, error);
-      }
-    }
-    
-    return opportunities.sort((a, b) => b.profitPercentage - a.profitPercentage);
-  }
-
-  private async analyzeDirectArbitrageForSwap(
-    swapData: SwapData,
-    currentPrice: number,
-    api: GSwapAPI
-  ): Promise<ArbitrageOpportunity | null> {
-    try {
-      const tokenInClassKey = api.createTokenClassKey(swapData.tokenIn);
-      const tokenOutClassKey = api.createTokenClassKey(swapData.tokenOut);
-      
-      const testAmount = 1;
-      
-      // Get quotes in both directions for the exact pair that was swapped
-      const quoteAB = await api.getQuote(tokenInClassKey, tokenOutClassKey, testAmount);
-      const quoteBA = await api.getQuote(tokenOutClassKey, tokenInClassKey, testAmount);
-      
-      if (!quoteAB || !quoteBA) return null;
-
-      const rateAB = quoteAB.outputAmount / quoteAB.inputAmount;
-      const rateBA = quoteBA.outputAmount / quoteBA.inputAmount;
-      
-      // Check for invalid rates
-      if (!isFinite(rateAB) || !isFinite(rateBA) || rateAB <= 0 || rateBA <= 0) {
-        return null;
-      }
-      
-      // Check if there's a profitable spread
-      const spread = rateAB - (1 / rateBA);
-      const profitPercentage = (spread / (1 / rateBA)) * 100;
-      
-      // Check for invalid profit calculation
-      if (!isFinite(profitPercentage) || !isFinite(spread)) {
-        return null;
-      }
-      
-      if (profitPercentage < config.minProfitThreshold) return null;
-
-      const maxTradeAmount = Math.min(
-        config.maxTradeAmount,
-        quoteAB.inputAmount * 10,
-        quoteBA.inputAmount * 10
-      );
-
-      if (maxTradeAmount <= 0) return null;
-
-      // Check if we have sufficient funds for trading
-      const fundsCheck = await api.checkTradingFunds(maxTradeAmount, tokenInClassKey, this.balanceSnapshot);
-
-      const buyPrice = 1 / rateBA;
-      const sellPrice = rateAB;
-      const estimatedProfit = spread * maxTradeAmount;
-      const priceDiscrepancy = Math.abs(currentPrice - rateAB) / currentPrice * 100;
-
-      // Final validation before creating opportunity
-      if (!isFinite(buyPrice) || !isFinite(sellPrice) || !isFinite(estimatedProfit) || !isFinite(priceDiscrepancy)) {
-        console.log(`     Direct arbitrage analysis: Invalid final values (buyPrice: ${buyPrice}, sellPrice: ${sellPrice}, estimatedProfit: ${estimatedProfit}, priceDiscrepancy: ${priceDiscrepancy})`);
-        return null;
-      }
-
-      return {
-        id: `direct-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-        tokenA: swapData.tokenIn.collection,
-        tokenB: swapData.tokenOut.collection,
-        tokenClassA: tokenInClassKey,
-        tokenClassB: tokenOutClassKey,
-        buyPrice,
-        sellPrice,
-        profitPercentage,
-        estimatedProfit,
-        maxTradeAmount,
-        buyQuote: quoteBA,
-        sellQuote: quoteAB,
-        hasFunds: fundsCheck.hasFunds,
-        currentBalance: fundsCheck.currentBalance,
-        shortfall: fundsCheck.shortfall,
-        timestamp: Date.now(),
-        currentMarketPrice: currentPrice,
-        priceDiscrepancy,
-        confidence: profitPercentage
-      };
-    } catch (error) {
-      console.error('Error analyzing direct arbitrage for swap:', error);
-      return null;
-    }
-  }
-
-  private async analyzeDirectArbitrage(
-    pair: TradingPair,
-    api: GSwapAPI,
-    quoteMap: QuoteMap
-  ): Promise<ArbitrageOpportunity | null> {
-    try {
-      const testAmount = 1;
-
-      // Get quotes in both directions
-      const quoteAB = await getQuoteFromCacheOrApi(quoteMap, api, pair.tokenClassA, pair.tokenClassB, testAmount);
-      const quoteBA = await getQuoteFromCacheOrApi(quoteMap, api, pair.tokenClassB, pair.tokenClassA, testAmount);
-      
-      if (!quoteAB || !quoteBA) return null;
-
-      const rateAB = quoteAB.outputAmount / quoteAB.inputAmount;
-      const rateBA = quoteBA.outputAmount / quoteBA.inputAmount;
-      
-      // Check if there's a profitable spread
-      const spread = rateAB - (1 / rateBA);
-      const profitPercentage = (spread / (1 / rateBA)) * 100;
-      
-      if (profitPercentage < config.minProfitThreshold) return null;
-
-      const maxTradeAmount = Math.min(
-        config.maxTradeAmount,
-        quoteAB.inputAmount * 10,
-        quoteBA.inputAmount * 10
-      );
-
-      if (maxTradeAmount <= 0) return null;
-
-      // Check if we have sufficient funds for trading
-      const fundsCheck = await api.checkTradingFunds(maxTradeAmount, pair.tokenClassA, this.balanceSnapshot);
-
-      return {
-        id: `direct-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-        tokenA: pair.tokenA.symbol,
-        tokenB: pair.tokenB.symbol,
-        tokenClassA: pair.tokenClassA,
-        tokenClassB: pair.tokenClassB,
-        buyPrice: 1 / rateBA,
-        sellPrice: rateAB,
-        profitPercentage,
-        estimatedProfit: spread * maxTradeAmount,
-        maxTradeAmount,
-        buyQuote: quoteBA,
-        sellQuote: quoteAB,
-        hasFunds: fundsCheck.hasFunds,
-        currentBalance: fundsCheck.currentBalance,
-        shortfall: fundsCheck.shortfall,
-        timestamp: Date.now()
-      };
-    } catch (error) {
-      console.error('Error analyzing direct arbitrage:', error);
-      return null;
-    }
-  }
+interface DirectArbitrageParams {
+  tokenA: string;
+  tokenB: string;
+  tokenClassA: string;
+  tokenClassB: string;
+  api: GSwapAPI;
+  balanceSnapshot: BalanceSnapshot;
+  quoteMap?: QuoteMap;
+  currentPrice?: number;
 }
 
 export class ArbitrageDetector {
-  private readonly strategyConstructors: ArbitrageStrategyConstructor[];
-
-  constructor(strategyConstructors?: ArbitrageStrategyConstructor[]) {
-    this.strategyConstructors = strategyConstructors ?? [
-      CrossPairArbitrageStrategy,
-      DirectArbitrageStrategy,
-    ];
-  }
-
-  private instantiateStrategies(balanceSnapshot: BalanceSnapshot): ArbitrageStrategy[] {
-    return this.strategyConstructors.map(StrategyCtor => new StrategyCtor(balanceSnapshot));
-  }
-
   async detectOpportunitiesForSwap(
     swapData: SwapData,
     currentPrice: number,
     api: GSwapAPI
   ): Promise<ArbitrageOpportunity[]> {
-    const allOpportunities: ArbitrageOpportunity[] = [];
+    const tokenInClassKey = api.createTokenClassKey(swapData.tokenIn);
+    const tokenOutClassKey = api.createTokenClassKey(swapData.tokenOut);
+
+    if (!this.involvesGala(tokenInClassKey, tokenOutClassKey)) {
+      return [];
+    }
 
     const balanceSnapshot = await api.getBalanceSnapshot();
-    const strategies = this.instantiateStrategies(balanceSnapshot);
+    const opportunity = await this.evaluateDirectArbitrage({
+      tokenA: swapData.tokenIn.collection,
+      tokenB: swapData.tokenOut.collection,
+      tokenClassA: tokenInClassKey,
+      tokenClassB: tokenOutClassKey,
+      api,
+      balanceSnapshot,
+      currentPrice,
+    });
 
-    for (const strategy of strategies) {
-      try {
-        const opportunities = await strategy.detectOpportunitiesForSwap(swapData, currentPrice, api);
-        allOpportunities.push(...opportunities);
-      } catch (error) {
-        console.error(`Error in strategy ${strategy.name}:`, error);
-      }
-    }
-    
-    // Remove duplicates and sort by profit
-    const uniqueOpportunities = this.removeDuplicateOpportunities(allOpportunities);
-    return uniqueOpportunities.sort((a, b) => b.profitPercentage - a.profitPercentage);
+    return opportunity ? [opportunity] : [];
   }
 
-  // Keep the old method for backward compatibility (if needed elsewhere)
   async detectAllOpportunities(
     pairs: TradingPair[],
     api: GSwapAPI,
     quoteMap: QuoteMap
   ): Promise<ArbitrageOpportunity[]> {
-    const allOpportunities: ArbitrageOpportunity[] = [];
+    if (pairs.length === 0) {
+      return [];
+    }
 
     const balanceSnapshot = await api.getBalanceSnapshot();
-    const strategies = this.instantiateStrategies(balanceSnapshot);
+    const opportunities: ArbitrageOpportunity[] = [];
 
-    for (const strategy of strategies) {
-      try {
-        console.log(`🔍 Running ${strategy.name}...`);
-        const opportunities = strategy.detectOpportunities ? await strategy.detectOpportunities(pairs, api, quoteMap) : [];
-        console.log(`   Found ${opportunities.length} opportunities`);
-        allOpportunities.push(...opportunities);
-      } catch (error) {
-        console.error(`Error in strategy ${strategy.name}:`, error);
+    for (const pair of pairs) {
+      if (!this.involvesGala(pair.tokenClassA, pair.tokenClassB)) {
+        continue;
+      }
+
+      const opportunity = await this.evaluateDirectArbitrage({
+        tokenA: pair.tokenA.symbol,
+        tokenB: pair.tokenB.symbol,
+        tokenClassA: pair.tokenClassA,
+        tokenClassB: pair.tokenClassB,
+        api,
+        balanceSnapshot,
+        quoteMap,
+      });
+
+      if (opportunity) {
+        opportunities.push(opportunity);
       }
     }
-    
-    // Remove duplicates and sort by profit
-    const uniqueOpportunities = this.removeDuplicateOpportunities(allOpportunities);
-    return uniqueOpportunities.sort((a, b) => b.profitPercentage - a.profitPercentage);
+
+    return opportunities.sort((a, b) => b.profitPercentage - a.profitPercentage);
   }
 
-  private removeDuplicateOpportunities(opportunities: ArbitrageOpportunity[]): ArbitrageOpportunity[] {
-    const seen = new Set<string>();
-    return opportunities.filter(opp => {
-      const key = `${opp.tokenA}-${opp.tokenB}-${opp.tokenClassA}-${opp.tokenClassB}`;
-      if (seen.has(key)) {
-        return false;
-      }
-      seen.add(key);
-      return true;
-    });
+  private involvesGala(tokenClassA: string, tokenClassB: string): boolean {
+    return tokenClassA === GALA_TOKEN_CLASS || tokenClassB === GALA_TOKEN_CLASS;
+  }
+
+  private async evaluateDirectArbitrage({
+    tokenA,
+    tokenB,
+    tokenClassA,
+    tokenClassB,
+    api,
+    balanceSnapshot,
+    quoteMap,
+    currentPrice,
+  }: DirectArbitrageParams): Promise<ArbitrageOpportunity | null> {
+    const quoteAB = await getQuoteFromCacheOrApi(
+      quoteMap,
+      api,
+      tokenClassA,
+      tokenClassB,
+      TEST_TRADE_AMOUNT
+    );
+    const quoteBA = await getQuoteFromCacheOrApi(
+      quoteMap,
+      api,
+      tokenClassB,
+      tokenClassA,
+      TEST_TRADE_AMOUNT
+    );
+
+    if (!quoteAB || !quoteBA) {
+      return null;
+    }
+
+    const rateAB = quoteAB.outputAmount / quoteAB.inputAmount;
+    const rateBA = quoteBA.outputAmount / quoteBA.inputAmount;
+
+    if (!isFinite(rateAB) || !isFinite(rateBA) || rateAB <= 0 || rateBA <= 0) {
+      return null;
+    }
+
+    const buyPrice = 1 / rateBA;
+    const sellPrice = rateAB;
+    const spread = sellPrice - buyPrice;
+
+    if (!isFinite(spread) || spread <= 0) {
+      return null;
+    }
+
+    const profitPercentage = (spread / buyPrice) * 100;
+
+    if (!isFinite(profitPercentage) || profitPercentage < config.minProfitThreshold) {
+      return null;
+    }
+
+    const maxTradeAmount = config.maxTradeAmount;
+    const fundsCheck = await api.checkTradingFunds(maxTradeAmount, tokenClassA, balanceSnapshot);
+    const estimatedProfit = spread * maxTradeAmount;
+
+    const marketPrice = typeof currentPrice === 'number' && currentPrice > 0 ? currentPrice : sellPrice;
+    const priceDiscrepancy = marketPrice > 0 ? (Math.abs(marketPrice - sellPrice) / marketPrice) * 100 : 0;
+
+    return {
+      id: `direct-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      tokenA,
+      tokenB,
+      tokenClassA,
+      tokenClassB,
+      buyPrice,
+      sellPrice,
+      profitPercentage,
+      estimatedProfit,
+      maxTradeAmount,
+      buyQuote: quoteBA,
+      sellQuote: quoteAB,
+      hasFunds: fundsCheck.hasFunds,
+      currentBalance: fundsCheck.currentBalance,
+      shortfall: fundsCheck.shortfall,
+      timestamp: Date.now(),
+      currentMarketPrice: marketPrice,
+      priceDiscrepancy,
+      confidence: profitPercentage,
+    };
   }
 }

--- a/src/trader/executor.ts
+++ b/src/trader/executor.ts
@@ -1,4 +1,4 @@
-import { GSwapAPI, SwapResult, SwapQuote } from '../api/gswap';
+import { GSwapAPI, SwapQuote, SwapResult } from '../api/gswap';
 import { ArbitrageOpportunity } from '../strategies/arbitrage';
 import { config } from '../config';
 
@@ -14,340 +14,132 @@ export interface TradeExecution {
   error?: string;
 }
 
-class TradeCancelledError extends Error {
-  constructor() {
-    super('Trade cancelled');
-    this.name = 'TradeCancelledError';
-  }
-}
-
-export interface TradeExecutorOptions {
-  maxRetries?: number;
-  baseRetryDelayMs?: number;
-  maxRetryDelayMs?: number;
-  quoteMaxAgeMs?: number;
-}
-
 export class TradeExecutor {
-  private activeTrades: Map<string, TradeExecution> = new Map();
-  private readonly maxRetries: number;
-  private readonly baseRetryDelayMs: number;
-  private readonly maxRetryDelayMs: number;
-  private readonly quoteMaxAgeMs: number;
+  private readonly activeTrades = new Map<string, TradeExecution>();
 
-  constructor(private api: GSwapAPI, options: TradeExecutorOptions = {}) {
-    const defaultMaxRetries = 3;
-    const defaultBaseDelay = 250;
-    const defaultMaxDelay = 1000;
-    const defaultQuoteMaxAge = 30_000;
+  constructor(private readonly api: GSwapAPI) {}
 
-    const providedBaseDelay = options.baseRetryDelayMs ?? defaultBaseDelay;
-    const providedMaxDelay = options.maxRetryDelayMs ?? defaultMaxDelay;
-
-    this.maxRetries = Math.max(1, options.maxRetries ?? defaultMaxRetries);
-    this.baseRetryDelayMs = Math.max(0, providedBaseDelay);
-    this.maxRetryDelayMs = Math.max(this.baseRetryDelayMs, providedMaxDelay);
-    this.quoteMaxAgeMs = Math.max(0, options.quoteMaxAgeMs ?? defaultQuoteMaxAge);
-  }
-
-  /**
-   * Execute an arbitrage opportunity
-   */
   async executeArbitrage(opportunity: ArbitrageOpportunity): Promise<TradeExecution> {
     const execution: TradeExecution = {
-      id: `exec-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      id: `exec-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
       opportunity,
       status: 'pending',
       startTime: Date.now(),
     };
 
+    if (this.activeTrades.size >= config.maxConcurrentTrades) {
+      execution.status = 'failed';
+      execution.error = 'Maximum concurrent trades exceeded';
+      execution.endTime = Date.now();
+      return execution;
+    }
+
     this.activeTrades.set(execution.id, execution);
 
     try {
-      console.log(`🚀 Starting arbitrage execution: ${execution.id}`);
-      console.log(`💰 Opportunity: ${opportunity.tokenA} -> ${opportunity.tokenB}`);
-      console.log(`📊 Buy price: ${opportunity.buyPrice.toFixed(6)}`);
-      console.log(`📊 Sell price: ${opportunity.sellPrice.toFixed(6)}`);
-      console.log(`📈 Expected profit: ${opportunity.profitPercentage.toFixed(2)}% (${opportunity.estimatedProfit.toFixed(2)})`);
+      await this.runDirectArbitrage(execution);
 
-      // Check if we have too many concurrent trades
-      if (this.activeTrades.size > config.maxConcurrentTrades) {
-        throw new Error('Maximum concurrent trades exceeded');
-      }
-
-      // Execute the arbitrage
-      await this.executeArbitrageSteps(execution);
-
-      if (this.isExecutionCancelled(execution)) {
-        if (!execution.endTime) {
-          execution.endTime = Date.now();
-        }
-        console.log(`🛑 Arbitrage execution cancelled before completion: ${execution.id}`);
-      } else {
+      if (execution.status !== 'cancelled') {
         execution.status = 'completed';
         execution.endTime = Date.now();
-
-        console.log(`✅ Arbitrage execution completed: ${execution.id}`);
-        console.log(`💰 Actual profit: ${execution.actualProfit?.toFixed(2) || 'Unknown'}`);
       }
-
     } catch (error) {
-      const isCancelled = error instanceof TradeCancelledError || execution.status === 'cancelled';
-
-      if (isCancelled) {
-        execution.status = 'cancelled';
+      if (execution.status === 'cancelled') {
         execution.error = 'Trade cancelled';
-        if (!execution.endTime) {
-          execution.endTime = Date.now();
-        }
-        console.log(`🛑 Arbitrage execution cancelled during processing: ${execution.id}`);
+        execution.endTime ??= Date.now();
       } else {
         execution.status = 'failed';
         execution.error = error instanceof Error ? error.message : 'Unknown error';
         execution.endTime = Date.now();
-        console.error(`❌ Arbitrage execution failed: ${execution.id}`, error);
       }
-    } finally {
-      // Clean up completed trades after a delay
-      const cleanupTimer = setTimeout(() => {
-        this.activeTrades.delete(execution.id);
-      }, 300000); // 5 minutes
-
-      cleanupTimer.unref?.();
     }
 
     return execution;
   }
 
-  private async executeArbitrageSteps(execution: TradeExecution): Promise<void> {
+  private async runDirectArbitrage(execution: TradeExecution): Promise<void> {
     const { opportunity } = execution;
 
-    // Step 1: Execute buy swap
-    this.throwIfCancelled(execution);
+    this.ensureNotCancelled(execution);
     execution.status = 'buying';
-    console.log(`🔄 Executing buy swap: ${opportunity.tokenClassA} -> ${opportunity.tokenClassB}`);
-
-    const buySwap = await this.executeSwapWithRetry(
+    const buySwap = await this.executeSwap(
       execution,
       opportunity.tokenClassA,
       opportunity.tokenClassB,
       opportunity.maxTradeAmount,
-      opportunity.buyQuote,
-      opportunity.timestamp
+      opportunity.buyQuote
     );
-
-    if (!buySwap || !buySwap.transactionHash) {
-      throw new Error('Buy swap failed');
-    }
-
     execution.buySwap = buySwap;
-    console.log(`✅ Buy swap completed: ${buySwap.transactionHash}`);
 
-    // Step 2: Execute sell swap
-    this.throwIfCancelled(execution);
+    this.ensureNotCancelled(execution);
     execution.status = 'selling';
-    console.log(`🔄 Executing sell swap: ${opportunity.tokenClassB} -> ${opportunity.tokenClassA}`);
-
-    const sellSwap = await this.executeSwapWithRetry(
+    const sellSwap = await this.executeSwap(
       execution,
       opportunity.tokenClassB,
       opportunity.tokenClassA,
-      buySwap.outputAmount, // Use the output from the buy swap
-      opportunity.sellQuote,
-      opportunity.timestamp
+      buySwap.outputAmount,
+      opportunity.sellQuote
     );
-
-    if (!sellSwap || !sellSwap.transactionHash) {
-      throw new Error('Sell swap failed');
-    }
-
     execution.sellSwap = sellSwap;
-    console.log(`✅ Sell swap completed: ${sellSwap.transactionHash}`);
 
-    // Calculate actual profit
-    if (execution.buySwap && execution.sellSwap) {
-      const totalCost = execution.buySwap.inputAmount;
-      const totalRevenue = execution.sellSwap.outputAmount;
-      execution.actualProfit = totalRevenue - totalCost;
-    }
+    execution.actualProfit = sellSwap.outputAmount - buySwap.inputAmount;
   }
 
-  private async executeSwapWithRetry(
+  private async executeSwap(
     execution: TradeExecution,
     inputTokenClass: string,
     outputTokenClass: string,
     inputAmount: number,
-    initialQuote?: SwapQuote,
-    quoteTimestamp?: number
+    quote?: SwapQuote
   ): Promise<SwapResult> {
-    let lastError: Error | null = null;
-    let cachedQuote: SwapQuote | undefined = initialQuote;
-    let cachedQuoteTimestamp: number | undefined = quoteTimestamp;
+    this.ensureNotCancelled(execution);
 
-    for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
-      if (execution.status === 'cancelled') {
-        throw new TradeCancelledError();
-      }
-      try {
-        console.log(`🔄 Executing swap (attempt ${attempt}/${this.maxRetries})`);
-        console.log(`   ${inputTokenClass} -> ${outputTokenClass}`);
-        console.log(`   Amount: ${inputAmount}`);
-
-        if (!this.isQuoteUsable(cachedQuote, inputTokenClass, outputTokenClass, inputAmount)) {
-          cachedQuote = undefined;
-          cachedQuoteTimestamp = undefined;
-        }
-
-        if (cachedQuote && this.isQuoteStale(cachedQuoteTimestamp)) {
-          console.log('⚠️  Cached quote is stale, requesting fresh pricing');
-          cachedQuote = undefined;
-          cachedQuoteTimestamp = undefined;
-        }
-
-        const result = await this.api.executeSwap(
-          inputTokenClass,
-          outputTokenClass,
-          inputAmount,
-          config.slippageTolerance,
-          cachedQuote
-        );
-
-        if (!result) {
-          throw new Error('Swap execution returned no result');
-        }
-
-        if (!result.transactionHash) {
-          throw new Error('Swap execution missing transaction hash');
-        }
-
-        console.log(`✅ Swap executed successfully: ${result.transactionHash}`);
-        console.log(`   Input: ${result.inputAmount}`);
-        console.log(`   Output: ${result.outputAmount}`);
-        console.log(`   Price: ${result.actualPrice.toFixed(6)}`);
-
-        return result;
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error('Swap execution failed');
-
-        if (this.shouldInvalidateCachedQuote(lastError)) {
-          cachedQuote = undefined;
-          cachedQuoteTimestamp = undefined;
-        }
-
-        if (this.isExecutionCancelled(execution)) {
-          throw new Error('Trade execution cancelled');
-        }
-
-        console.warn(`⚠️  Swap execution failed (attempt ${attempt}/${this.maxRetries}):`, lastError.message);
-
-        if (attempt < this.maxRetries) {
-          const delay = this.getAdaptiveRetryDelay(attempt);
-          await this.delay(delay);
-        }
-      }
-    }
-
-    if (execution.status === 'cancelled') {
-      throw new TradeCancelledError();
-    }
-
-    throw lastError || new Error('Swap execution failed after all retries');
-  }
-
-  private delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
-
-  private getAdaptiveRetryDelay(attempt: number): number {
-    const cappedBase = Math.min(this.baseRetryDelayMs * attempt, this.maxRetryDelayMs);
-    const jitter = Math.random() * this.baseRetryDelayMs;
-    return Math.round(cappedBase + jitter);
-  }
-
-  private isQuoteUsable(
-    quote: SwapQuote | undefined,
-    inputTokenClass: string,
-    outputTokenClass: string,
-    inputAmount: number
-  ): quote is SwapQuote {
-    if (!quote) {
-      return false;
-    }
-
-    const tokensMatch =
-      quote.inputToken === inputTokenClass && quote.outputToken === outputTokenClass;
-
-    if (!tokensMatch) {
-      return false;
-    }
-
-    const tolerance = Math.max(1e-8, Math.abs(inputAmount) * 1e-6);
-    const amountMatches = Math.abs(quote.inputAmount - inputAmount) <= tolerance;
-    return amountMatches && quote.outputAmount > 0;
-  }
-
-  private isQuoteStale(timestamp?: number): boolean {
-    if (!timestamp) {
-      return false;
-    }
-
-    return Date.now() - timestamp > this.quoteMaxAgeMs;
-  }
-
-  private shouldInvalidateCachedQuote(error: Error): boolean {
-    const message = error.message.toLowerCase();
-    return (
-      message.includes('slippage') ||
-      message.includes('price impact') ||
-      message.includes('quote') ||
-      message.includes('tolerance')
+    const result = await this.api.executeSwap(
+      inputTokenClass,
+      outputTokenClass,
+      inputAmount,
+      config.slippageTolerance,
+      quote
     );
+
+    if (!result || !result.transactionHash) {
+      throw new Error('Swap execution failed');
+    }
+
+    this.ensureNotCancelled(execution);
+    return result;
   }
 
-  private isExecutionCancelled(execution: TradeExecution): boolean {
-    return execution.status === 'cancelled';
-  }
-
-  private throwIfCancelled(execution: TradeExecution): void {
-    if (this.isExecutionCancelled(execution)) {
-      throw new Error('Trade execution cancelled');
+  private ensureNotCancelled(execution: TradeExecution): void {
+    if (execution.status === 'cancelled') {
+      throw new Error('Trade cancelled');
     }
   }
 
-  /**
-   * Get all active trades
-   */
   getActiveTrades(): TradeExecution[] {
     return Array.from(this.activeTrades.values());
   }
 
-  /**
-   * Get trade execution by ID
-   */
   getTradeExecution(id: string): TradeExecution | undefined {
     return this.activeTrades.get(id);
   }
 
-  /**
-   * Cancel a specific trade execution
-   */
   async cancelTradeExecution(id: string): Promise<boolean> {
     const execution = this.activeTrades.get(id);
     if (!execution) {
       return false;
     }
 
+    if (execution.status === 'completed' || execution.status === 'failed') {
+      return false;
+    }
+
     execution.status = 'cancelled';
     execution.error = 'Trade cancelled';
     execution.endTime = Date.now();
-
-    console.log(`🛑 Trade execution cancelled: ${id}`);
     return true;
   }
 
-  /**
-   * Get trading statistics
-   */
   getTradingStats(): {
     totalTrades: number;
     completedTrades: number;
@@ -356,11 +148,14 @@ export class TradeExecutor {
     averageProfit: number;
     successRate: number;
   } {
-    const trades = Array.from(this.activeTrades.values());
-    const completedTrades = trades.filter(t => t.status === 'completed');
-    const failedTrades = trades.filter(t => t.status === 'failed');
-    
-    const totalProfit = completedTrades.reduce((sum, t) => sum + (t.actualProfit || 0), 0);
+    const trades = this.getActiveTrades();
+    const completedTrades = trades.filter(trade => trade.status === 'completed');
+    const failedTrades = trades.filter(trade => trade.status === 'failed');
+
+    const totalProfit = completedTrades.reduce(
+      (sum, trade) => sum + (trade.actualProfit ?? 0),
+      0
+    );
     const averageProfit = completedTrades.length > 0 ? totalProfit / completedTrades.length : 0;
     const successRate = trades.length > 0 ? (completedTrades.length / trades.length) * 100 : 0;
 
@@ -374,28 +169,21 @@ export class TradeExecutor {
     };
   }
 
-  /**
-   * Get detailed trade history
-   */
   getTradeHistory(): TradeExecution[] {
-    return Array.from(this.activeTrades.values()).sort((a, b) => b.startTime - a.startTime);
+    return this.getActiveTrades().sort((a, b) => b.startTime - a.startTime);
   }
 
-  /**
-   * Check if we can execute a new trade
-   */
   canExecuteTrade(): boolean {
     return this.activeTrades.size < config.maxConcurrentTrades;
   }
 
-  /**
-   * Get current trading capacity
-   */
   getTradingCapacity(): { current: number; max: number; available: number } {
+    const max = config.maxConcurrentTrades;
+    const current = this.activeTrades.size;
     return {
-      current: this.activeTrades.size,
-      max: config.maxConcurrentTrades,
-      available: config.maxConcurrentTrades - this.activeTrades.size
+      current,
+      max,
+      available: Math.max(0, max - current),
     };
   }
 }


### PR DESCRIPTION
## Summary
- replace the arbitrage module with a lean direct-only detector that reuses cached quotes and balance snapshots
- streamline the trade executor to sequentially manage buy and sell swaps with simple cancellation handling
- refresh the arbitrage and executor unit tests to cover the simplified behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1830b80bc832882e0f6c894da941e