### PR TITLE
Refresh quotes before executing arbitrage trades

### DIFF
--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -84,6 +84,10 @@ describe('Basic Functionality Tests', () => {
     it('should pass directionally correct quotes to executeSwap', async () => {
       const opportunity = createMockArbitrageOpportunity();
 
+      mockApi.getQuote
+        .mockResolvedValueOnce(opportunity.quoteAToB)
+        .mockResolvedValueOnce(opportunity.quoteBToA);
+
       mockApi.executeSwap.mockResolvedValueOnce(
         createMockSwapResult('0xbuy', {
           inputAmount: opportunity.maxTradeAmount,


### PR DESCRIPTION
## Summary
- fetch fresh amount-specific quotes before executing direct arbitrage trades and recompute profitability
- cancel opportunities that fall below the profit threshold and pass validated quotes into swap execution
- extend executor tests to prime quotes and add coverage for unprofitable re-quote scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1b6fd99648328a9a250e29d0d7867